### PR TITLE
Remove list.fr and migrate to Adguard Français

### DIFF
--- a/filter_lists/regional.json
+++ b/filter_lists/regional.json
@@ -122,11 +122,11 @@
     },
     {
         "uuid": "9852EFC4-99E4-4F2D-A915-9C3196C7A1DE",
-        "url": "https://easylist-downloads.adblockplus.org/liste_fr.txt",
-        "title": "EasyList Liste FR",
+        "url": "https://filters.adtidy.org/extension/ublock/filters/16.txt",
+        "title": "AdGuard Français",
         "format": "Standard",
         "langs": ["fr"],
-        "support_url": "https://forums.lanik.us/viewforum.php?f=91",
+        "support_url": "https://github.com/AdguardTeam/AdguardFilters#adguard-filters",
         "component_id": "emaecjinaegfkoklcdafkiocjhoeilao",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsbqIWuMS7r2OPXCsIPbbLG1H/d3NM9uzCMscw7R9ZV3TwhygvMOpZrNp4Y4hImy2H+HE0OniCqzuOAaq7+SHXcdHwItvLKtnRmeWgdqxgEdzJ8rZMWnfi+dODTbA4QvxI6itU5of8trDFbLzFqgnEOBk8ZxtjM/M5v3UeYh+EYHSEyHnDSJKbKevlXC931xlbdca0q0Ps3Ln6w/pJFByGbOh212mD/PvwS6jIH3LYjrMVUMefKC/ywn/AAdnwM5mGirm1NflQCJQOpTjIhbRIXBlACfV/hwI1lqfKbFnyr4aPOdg3JcOZZVoyi+ko3rKG3vH9JPWEy24Ys9A3SYpTwIDAQAB",
         "desc": "Removes advertisements from French websites"


### PR DESCRIPTION
Due to uBO moving away from Liste.fr, we should do the same.

https://github.com/uBlockOrigin/uAssets/commit/529643bdcef9fb67a79153f44c009b5f0f97dfe0#commitcomment-40658298

just a copy of https://github.com/brave/adblock-rust/pull/118