### PR TITLE
Remove notifications list, no longer needed

### DIFF
--- a/filter_lists/default.json
+++ b/filter_lists/default.json
@@ -61,12 +61,5 @@
         "title": "Disconnect rules",
         "format": "Standard",
         "support_url": "https://github.com/brave/adblock-lists"
-    },
-    {
-        "uuid": "E55EAE71-8068-4903-A426-0F9EB3B332AC",
-        "url": "https://easylist-downloads.adblockplus.org/fanboy-notifications.txt",
-        "title": "Notification List",
-        "format": "Standard",
-        "support_url": "https://easylist.to/"
     }
 ]


### PR DESCRIPTION
Since we're merging notifications servers into Easyprivacy, we don't need this list any more. Safe to not include this list.


Just a copy of https://github.com/brave/adblock-rust/pull/115