### PR TITLE
Update gitlab to github mirror for urlhaus-filter-online.txt

### DIFF
--- a/filter_lists/default.json
+++ b/filter_lists/default.json
@@ -57,7 +57,7 @@
     },
     {
         "uuid": "56b195f1-4b7b-4070-94c1-b720a650c8bc",
-        "url": "https://gitlab.com/curben/urlhaus-filter/raw/master/urlhaus-filter-online.txt",
+        "url": "https://raw.githubusercontent.com/curbengh/urlhaus-filter/master/urlhaus-filter-online.txt",
         "title": "URLhaus Malicious URL Blocklist",
         "format": "Standard",
         "support_url": "https://gitlab.com/curben/urlhaus-filter"


### PR DESCRIPTION
Gitlab is having issues, `You cannot access the raw file. Please wait a minute.` (has been like this for a few hours) . Possibly limiting downloads of this file https://gitlab.com/curben/urlhaus-filter/-/blob/master/urlhaus-filter-online.txt

Pulled the github mirror from: https://github.com/brave/uBlock/blob/59b6f1dd676d0a733b0979867b294ef55c30bdda/assets/assets.json#L145

If it looks @antonok-edm 