### PR TITLE
Add more specific list descriptors for migration

### DIFF
--- a/filter_lists/default.json
+++ b/filter_lists/default.json
@@ -82,5 +82,26 @@
         "title": "Brave Social",
         "format": "Standard",
         "support_url": "https://github.com/brave/adblock-lists"
+    },
+    {
+        "uuid": "805662ef-a1aa-4948-9f6e-72603823e886",
+        "url": "https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/brave-unbreak.txt",
+        "title": "Brave Unbreak",
+        "format": "Standard",
+        "support_url": "https://github.com/brave/adblock-lists"
+    },
+    {
+        "uuid": "08ac2f6d-f7c5-4670-a8ec-9b2591bdfd0d",
+        "url": "https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/brave-ios-specific.txt",
+        "title": "Brave iOS-Specific Rules",
+        "format": "Standard",
+        "support_url": "https://github.com/brave/adblock-lists"
+    },
+    {
+        "uuid": "49254a7e-396e-4d1f-af48-f5730e22e1ce",
+        "url": "https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/brave-android-specific.txt",
+        "title": "Brave Android-Specific Rules",
+        "format": "Standard",
+        "support_url": "https://github.com/brave/adblock-lists"
     }
 ]


### PR DESCRIPTION
For https://github.com/brave/adblock-lists/pull/495. We'll remove the previous Brave Unbreak (uuid `2FBEB0BC-E2E1-4170-BAA9-05E76AAB5BA5`) and Brave Social once list contents are fully migrated.