### PR TITLE
Update Cookie list domain

### DIFF
--- a/filter_lists/regional.json
+++ b/filter_lists/regional.json
@@ -100,7 +100,7 @@
     },
     {
         "uuid": "AC023D22-AE88-4060-A978-4FEEEC4221693",
-        "url": "https://easylist-downloads.adblockplus.org/easylist-cookie.txt",
+        "url": "https://secure.fanboy.co.nz/fanboy-cookiemonster.txt",
         "title": "Easylist-Cookie List - Filter Obtrusive Cookie Notices",
         "format": "Standard",
         "langs": [],


### PR DESCRIPTION
Changing domain for Easylist Cookie for legal reasons.

updated in uBO also.

https://github.com/gorhill/uBlock/commit/d037d9dcedd7b9f228f422e893b367c63b5e8529