### PR TITLE
Update filter list for easylist_cookie

### DIFF
--- a/filter_lists/regional.json
+++ b/filter_lists/regional.json
@@ -100,7 +100,7 @@
     },
     {
         "uuid": "AC023D22-AE88-4060-A978-4FEEEC4221693",
-        "url": "https://easylist-downloads.adblockplus.org/easylist-cookie.txt",
+        "url": "https://secure.fanboy.co.nz/fanboy-cookiemonster.txt",
         "title": "Easylist-Cookie List - Filter Obtrusive Cookie Notices",
         "format": "Standard",
         "langs": [],


### PR DESCRIPTION
`https://easylist-downloads.adblockplus.org/easylist-cookie.txt` is 404'ing. 

Fix url for Easylist_cookie