### PR TITLE
Update Annoyances to fanboy.co.nz

### DIFF
--- a/filter_lists/regional.json
+++ b/filter_lists/regional.json
@@ -111,7 +111,7 @@
     },
     {
         "uuid": "67E792D4-AE03-4D1A-9EDE-80E01C81F9B8",
-        "url": "https://easylist-downloads.adblockplus.org/fanboy-annoyance.txt",
+        "url": "https://secure.fanboy.co.nz/fanboy-annoyance.txt",
         "title": "Fanboy Annoyances List",
         "format": "Standard",
         "langs": [],


### PR DESCRIPTION
Filter list will be moving away from `https://easylist-downloads.adblockplus.org/` (20/03).

We can update to my host