### PR TITLE
Fix Greek list to use Github instead

### DIFF
--- a/filter_lists/regional.json
+++ b/filter_lists/regional.json
@@ -155,7 +155,7 @@
     },
     {
         "uuid": "6C0F4C7F-969B-48A0-897A-14583015A587",
-        "url": "https://www.void.gr/kargig/void-gr-filters.txt",
+        "url": "https://raw.githubusercontent.com/kargig/greek-adblockplus-filter/master/void-gr-filters.txt",
         "title": "Greek AdBlock Filter",
         "format": "Standard",
         "langs": ["el"],


### PR DESCRIPTION
SSL cert issues on  `https://www.void.gr/kargig/void-gr-filters.txt`

https://github.com/kargig/greek-adblockplus-filter/issues/101

Just easier to use Github directly, like other filter lists.