### PR TITLE
Remove ios as a default list on desktop

### DIFF
--- a/filter_lists/default.json
+++ b/filter_lists/default.json
@@ -105,13 +105,6 @@
         "support_url": "https://github.com/brave/adblock-lists"
     },
     {
-        "uuid": "08ac2f6d-f7c5-4670-a8ec-9b2591bdfd0d",
-        "url": "https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/brave-ios-specific.txt",
-        "title": "Brave iOS-Specific Rules",
-        "format": "Standard",
-        "support_url": "https://github.com/brave/adblock-lists"
-    },
-    {
         "uuid": "49254a7e-396e-4d1f-af48-f5730e22e1ce",
         "url": "https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/brave-android-specific.txt",
         "title": "Brave Android-Specific Rules",


### PR DESCRIPTION
No need to import ios list fixes into Brave desktop.

Which should also resolve google-funding issues on https://www.androidpolice.com/2021/05/19/will-your-existing-smartwatch-get-google-and-samsungs-new-wear-os/ 