### PR TITLE
Add script to generate metadata.json + improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,6 @@ The `filter_lists/*.json` files are lists of elements, each describing a filter 
 
 - `format` is either ABP/uBO-style format ("Standard", most common) or IP address and hostname ("Hosts").
 
-- `include_redirect_urls` permits parsing of `redirect-url` filter option. This has security implications and should usually be `false`.
+- `include_redirect_urls` permits parsing of `redirect-url` filter option. This has security implications. This field is optional and defaults to `false`. 
 
 - `support_url` is somewhere a user can ask for help with the filter list.

--- a/README.md
+++ b/README.md
@@ -34,3 +34,30 @@ Use `npm run verify` after modifying the resources or metadata file to ensure th
 - `resourcePath` specifies the path to the content of the resource. It should be relative to the `resources` directory in the root of this repository.
 
 In general, this format corresponds to the `Resource` struct from [adblock-rust](https://github.com/brave/adblock-rust), but the base64-encoded `content` field is replaced by a path to a file for better maintainability. This library will translate the `resourcePath` field back to a base64-encoded `content` field when ready for use.
+
+## Filter list description format
+
+The `filter_lists/*.json` files are lists of elements, each describing a filter list. The format for each element is:
+
+```json
+{
+    "uuid": "49254a7e-396e-4d1f-af48-f5730e22e1ce",
+    "url": "https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/new-list.txt",
+    "title": "New Filter Rules",
+    "format": "Standard",
+    "include_redirect_urls": false,
+    "support_url": "https://github.com/brave/adblock-lists"
+}
+```
+
+- `uuid` is a unique identifier used by the browser to identify a filter list, should be generated.
+
+- `url` is the URL where the filter list is actually located and can be downloaded from. Filter list should be a list of rules in the format specified in `format` in a `.txt` file.
+
+- `title` is a human-readable title for the filter list.
+
+- `format` is either ABP/uBO-style format ("Standard", most common) or IP address and hostname ("Hosts").
+
+- `include_redirect_urls` permits parsing of `redirect-url` filter option. This has security implications and should usually be `false`.
+
+- `support_url` is somewhere a user can ask for help with the filter list.

--- a/generateMetadataJsonFromScriptResources.js
+++ b/generateMetadataJsonFromScriptResources.js
@@ -1,0 +1,20 @@
+const fs = require("fs");
+const path = require("path");
+
+const metadataJsonFile = "metadata.json";
+const resourcesDir = "resources";
+
+console.debug(`Creating ${metadataJsonFile}...`);
+const resources = fs.readdirSync(resourcesDir);
+const metadataList = resources.map((file) => {
+  return {
+    name: path.basename(file, ".js"),
+    aliases: [],
+    kind: { mime: "application/javascript" },
+    resourcePath: path.basename(file),
+  };
+});
+
+console.debug(`Writing ${metadataJsonFile}... `);
+// Pretty print out
+fs.writeFileSync(metadataJsonFile, JSON.stringify(metadataList, null, 4));

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "build": "node build",
-    "test": "node verify"
+    "test": "node verify",
+    "generateMetadata": "node generateMetadataJsonFromScriptResources.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Simple PR that adds a script to generate metadata.json from local resources that can then be checked in
Add description of filter list description format to README
This is in preparation for the automated sugarcoat pipeline that will use this script