### PR TITLE
Use both "ja" and "jp" for Japanese list

### DIFF
--- a/filter_lists/regional.json
+++ b/filter_lists/regional.json
@@ -257,7 +257,7 @@
         "url": "https://filters.adtidy.org/ios/filters/7.txt",
         "title": "Adguard Japanese filters (日本用フィルタ)",
         "format": "Standard",
-        "langs": ["jp"],
+        "langs": ["ja", "jp"],
         "support_url": "https://github.com/AdguardTeam/AdguardFilters",
         "component_id": "ghnjmapememheddlfgmklijahiofgkea",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsOoGwN4i751gHi1QmHMkFZCXFPseO/Q8qKOQViZI7p6THKqF1G3uHNxh8NjwKfsdcJLyZbnWx7BvDeyUw3K9hqWw4Iq6C0Ta1YEqEJFhcltV7J7aCMPJHdjZk5rpya9eXTWX1hfIYOvujPisKuwMNUmnlpaeWThihf4twu9BUn/X6+jcaqVaQ73q5TLS5vp13A9q2qSbEa79f/uUT8oKzN4S/GorQ6faS4bOl3iHuCT9abVXdy80WSut4bBERKgbc+0aJvi1dhpbCeM4DxVViM2ZccKvxSpyx4NvWj56dNKqFLvzoA4/Chz1udxifIXUHh0701s1Y4fLpY0wWP0uXQIDAQAB",


### PR DESCRIPTION
Changing to `"jp"` only was causing the list to not be preselected according to https://github.com/brave/adblock-resources/pull/56#issuecomment-1057997940. We should figure out why we've been having conflicting reports, but in the meantime it's fine to have both values here.