### PR TITLE
Narrow selector on deamp to not affect non-AMP links

### DIFF
--- a/resources/de-amp.js
+++ b/resources/de-amp.js
@@ -1,12 +1,12 @@
 (function () {
   if (typeof deAmpEnabled !== 'undefined' && deAmpEnabled) {
-    const selector = 'a'
     const attr = 'jsaction'
+    const selector = `a[data-amp-title][${attr}]`
     let timer
     const rmattr = () => {
       timer = undefined
       try {
-        const nodes = document.querySelectorAll(selector)
+        const nodes = Array.from(document.querySelectorAll(selector))
         for (const node of nodes) {
           node.removeAttribute(attr)
         }

--- a/resources/de-amp.js
+++ b/resources/de-amp.js
@@ -6,7 +6,7 @@
     const rmattr = () => {
       timer = undefined
       try {
-        const nodes = Array.from(document.querySelectorAll(selector))
+        const nodes = document.querySelectorAll(selector)
         for (const node of nodes) {
           node.removeAttribute(attr)
         }


### PR DESCRIPTION
from Slack

```Hi! I got some feedback for De-Amp. On Desktop and Android, when I click close button on Google image search, it move to google search top page. And it works correctly(close the side panel) if De-Amp is disabled.```