### PR TITLE
Temporarily disable latvian-list

### DIFF
--- a/filter_lists/regional.json
+++ b/filter_lists/regional.json
@@ -77,17 +77,6 @@
         "desc": "Removes advertisements from German websites"
     },
     {
-        "uuid": "9EF6A21C-5014-4199-95A2-A82491274203",
-        "url": "https://adblock.dk/block.csv",
-        "title": "Schacks Adblock Plus liste",
-        "format": "Standard",
-        "langs": ["da"],
-        "support_url": "https://henrik.schack.dk/adblock/",
-        "component_id": "facajiciiepdpjnoifonbfgcnlbpbieo",
-        "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxvmMjXthrTjGl0WDrL+4qYSVao5vKPGerr2VeUiZ1o94+P0IJyZzq3d7UP2nOvhveGl15YYxYss+sD/sUkUW57XMx+H4TF5OzGCwV8nkz4VoMIfEU6CKgYmRGHV2VoMdIHG7R++jX20+GAoeBw+aBx9+AHlBouf1kvqbkutVh+Bre1cVa6YsgsPVcmhiEp7wjz2yB23f44+pBIQgWlKWn7z9e1osG4LUCGk6gavtRoNGS3TAUf1Sq9EUibFJVmBjujVoiQKD8GIFKmLM9Fxl1Q+xgG2PCCSBz5lSesHkphDpwhszedurpKbWsnsRPqbqR3GmpceKQheWL/Y56tf2gwIDAQAB",
-        "desc": "Removes advertisements from Danish websites"
-    },
-    {
         "uuid": "0783DBFD-B5E0-4982-9B4A-711BDDB925B7",
         "url": "https://adblock.ee/list.php",
         "title": "Eesti saitidele kohandatud filter",


### PR DESCRIPTION
 `Unhandled rejection: Error: Error status code 502 returned for URL: https://notabug.org/latvian-list/adblock-latvian/raw/master/lists/latvian-list.txt`

With no resolution so far, we should temporarily disable this list until it's restored. https://notabug.org/latvian-list/adblock-latvian is having hosting issues with no ETA.  