### PR TITLE
Remove UUIDs for default lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ The `filter_lists/*.json` files are lists of elements, each describing a filter 
 
 ```json
 {
-    "uuid": "49254a7e-396e-4d1f-af48-f5730e22e1ce",
     "url": "https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/new-list.txt",
     "title": "New Filter Rules",
     "format": "Standard",
@@ -51,8 +50,6 @@ The `filter_lists/*.json` files are lists of elements, each describing a filter 
     "support_url": "https://github.com/brave/adblock-lists"
 }
 ```
-
-- `uuid` is a unique identifier used by the browser to identify a filter list, should be generated.
 
 - `url` is the URL where the filter list is actually located and can be downloaded from. Filter list should be a list of rules in the format specified in `format` in a `.txt` file.
 

--- a/filter_lists/default.json
+++ b/filter_lists/default.json
@@ -1,125 +1,107 @@
 [
     {
-        "uuid": "AAB94120-6CD9-4A96-9480-D6D323C73909",
         "url": "https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/filters.txt",
         "title": "uBlock Origin Filters",
         "format": "Standard",
         "support_url": "https://github.com/uBlockOrigin/uAssets"
     },
     {
-        "uuid": "9F1AFA33-F034-4AE9-A927-6C293867EAF1",
         "url": "https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/filters-2020.txt",
         "title": "uBlock Origin 2020 Filters",
         "format": "Standard",
         "support_url": "https://github.com/uBlockOrigin/uAssets"
     },
     {
-        "uuid": "0E51623E-A758-4C44-B988-6F01336C480A",
         "url": "https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/filters-2021.txt",
         "title": "uBlock Origin 2021 Filters",
         "format": "Standard",
         "support_url": "https://github.com/uBlockOrigin/uAssets"
     },
     {
-        "uuid": "B7EC7540-CFB1-4D0C-BAEC-257DC00A6B31",
         "url": "https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/filters-2022.txt",
         "title": "uBlock Origin 2022 Filters",
         "format": "Standard",
         "support_url": "https://github.com/uBlockOrigin/uAssets"
     },
     {
-        "uuid": "4dda991a-cf59-4acf-82dc-c93bf38fbb31",
         "url": "https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/badware.txt",
         "title": "uBlock Origin filters - Badware risks",
         "format": "Standard",
         "support_url": "https://github.com/uBlockOrigin/uAssets"
     },
     {
-        "uuid": "744e5fb2-5446-4578-a097-68efd098ed5e",
         "url": "https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/privacy.txt",
         "title": "uBlock Origin filters – Privacy",
         "format": "Standard",
         "support_url": "https://github.com/uBlockOrigin/uAssets"
     },
     {
-        "uuid": "e3efec89-1902-4378-b49d-79de6e06aa1a",
         "url": "https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/resource-abuse.txt",
         "title": "uBlock Origin filters – Resource abuse",
         "format": "Standard",
         "support_url": "https://github.com/uBlockOrigin/uAssets"
     },
     {
-        "uuid": "200392E7-9A0F-40DF-86EB-6AF7E4071322",
         "url": "https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/unbreak.txt",
         "title": "uBlock Origin filters - Unbreak",
         "format": "Standard",
         "support_url": "https://github.com/uBlockOrigin/uAssets"
     },
     {
-        "uuid": "67F880F5-7602-4042-8A3D-01481FD7437A",
         "url": "https://easylist.to/easylist/easylist.txt",
         "title": "EasyList",
         "format": "Standard",
         "support_url": "https://easylist.to/"
     },
     {
-        "uuid": "48010209-AD34-4DF5-A80C-3D2A7C3920C0",
         "url": "https://easylist.to/easylist/easyprivacy.txt",
         "title": "EasyPrivacy",
         "format": "Standard",
         "support_url": "https://easylist.to/"
     },
     {
-        "uuid": "56b195f1-4b7b-4070-94c1-b720a650c8bc",
         "url": "https://malware-filter.gitlab.io/malware-filter/urlhaus-filter-agh.txt",
         "title": "URLhaus Malicious URL Blocklist",
         "format": "Standard",
         "support_url": "https://gitlab.com/malware-filter/urlhaus-filter"
     },
     {
-        "uuid": "40e22155-6b6d-43fc-a407-6844af78025a",
         "url": "https://pgl.yoyo.org/adservers/serverlist.php?hostformat=adblockplus&showintro=1&mimetype=plaintext",
         "title": "Peter Lowe's Ad and tracking server list",
         "format": "Standard",
         "support_url": "https://pgl.yoyo.org/adservers/"
     },
     {
-        "uuid": "2FBEB0BC-E2E1-4170-BAA9-05E76AAB5BA5",
         "url": "https://raw.githubusercontent.com/brave/adblock-lists/master/brave-unbreak.txt",
         "title": "Brave Unbreak",
         "format": "Standard",
         "support_url": "https://github.com/brave/adblock-lists"
     },
     {
-        "uuid": "BCB1AFD7-7563-4BD4-B1F1-AEA01D38E982",
         "url": "https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/brave-specific.txt",
         "title": "Brave Specific",
         "format": "Standard",
         "support_url": "https://github.com/brave/adblock-lists"
     },
     {
-        "uuid": "9752d6b2-9e5d-4d56-a7e8-c2ee0f181ea3",
         "url": "https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/brave-social.txt",
         "title": "Brave Social",
         "format": "Standard",
         "support_url": "https://github.com/brave/adblock-lists"
     },
     {
-        "uuid": "805662ef-a1aa-4948-9f6e-72603823e886",
         "url": "https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/brave-unbreak.txt",
         "title": "Brave Unbreak",
         "format": "Standard",
         "support_url": "https://github.com/brave/adblock-lists"
     },
     {
-        "uuid": "49254a7e-396e-4d1f-af48-f5730e22e1ce",
         "url": "https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/brave-android-specific.txt",
         "title": "Brave Android-Specific Rules",
         "format": "Standard",
         "support_url": "https://github.com/brave/adblock-lists"
     },
     {
-        "uuid": "b0433353-1144-473c-8e25-19fb035024b7",
         "url": "https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/brave-sugarcoat.txt",
         "title": "SugarCoat Rules",
         "format": "Standard",

--- a/verify.js
+++ b/verify.js
@@ -22,7 +22,6 @@ tap.test('resources are parsed OK by adblock-rust', childTest => {
 
 tap.test('default filter lists are correctly formatted', childTest => {
     defaultLists.forEach(list => {
-        tap.ok(list.uuid !== undefined && typeof list.uuid === 'string')
         tap.ok(list.url !== undefined && typeof list.url === 'string')
         tap.ok(list.title !== undefined && typeof list.title === 'string')
         let supportedFormat = false


### PR DESCRIPTION
After some investigation, it appears the UUIDs for default lists are never actually used anywhere, and it should be possible to just remove them altogether.