### PR TITLE
More plaintext components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+*.pem

--- a/README.md
+++ b/README.md
@@ -60,3 +60,16 @@ The `filter_lists/*.json` files are lists of elements, each describing a filter 
 - `include_redirect_urls` permits parsing of `redirect-url` filter option. This has security implications. This field is optional and defaults to `false`. 
 
 - `support_url` is somewhere a user can ask for help with the filter list.
+
+## Adding a new list
+
+The `generate_component.sh` script can be used to help create a new filter list component.
+It will generate:
+- A public key (corresponding to the `base64_public_key` field)
+- A component ID (corresponding to the `component_id` field)
+- The component's private key (in a new PEM file)
+
+The script should be run with no arguments.
+The resulting PEM file will be named `ad-block-updater-<component_id>.pem`.
+This file should be uploaded as a secret to Brave's `Extension Developers` vault in 1Password.
+Once it is uploaded, devops will also need to sync it the with Jenkins so that it can be used to build the component.

--- a/filter_lists/regional.json
+++ b/filter_lists/regional.json
@@ -8,7 +8,11 @@
         "support_url": "https://forums.lanik.us/viewforum.php?f=98",
         "component_id": "gpgegghiabhggiplapgdfnfcmodkccji",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnbHn298ZQjKnWlC6NgkvS3Dr7Neu87d1h8s3b9GTlc1QNDWiYgY5IfWVq/1FBw2nUFE/v8fNJg8quq8Z2nS8dYiJDVSGRggiCooa0OTCARL0BsGxHZO6s2QROYIcxPVnzISqg5zRIBc+8npE68uVUrDR6q/KdJ8siL2hrR/NybPp+uTK44lHOEIBFm8ih1rC6z+Y5dHfhax0CuL6wlWwVNcFe1macYEcOXShwkUOADh6rEBQZKJmv474xJutmB8nIpGq7C2Hn2HNNyfA6tYmhVlsaeEC44phGITKDai03wFsWWkHQPEU5HwFzKQGIBFwudyO8iigO5m+d3XSzgSZtQIDAQAB",
-        "desc": "Removes advertisements on Arabic websites"
+        "desc": "Removes advertisements on Arabic websites",
+        "list_text_component": {
+            "component_id": "mpgdjfnjjmglioiflfioiappfbdbkeno",
+            "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAr3arBYpWfbSQIYLDp6nVB4aQG+2r5NOh1n5YuD8zhYa8lN4G6m1/JqcMkbK/KE1ujqG4q9Orh5d0FjumAtdzw/KkEEg14OKmu3+xeHxV2YbIDJGEW7aTMwlqO0Nz0Da+Z41hbMLcjjCHl2KrSoAM4ogUYVtYW1GLplfH3P5ss+hM1qrwBsPI+pXIMyK1ZqTc8552+SxQFJ7RFbn1h1t9cSu0JoNw3SiIGmrOT45ZROeQ3D5tP1MCPqnOsanTeo0NTnt65AuGhj5EvOcSGZnbhhQulwpzA72r1reQ3wBlXjdIR0w1S1wAn75LXYgPcBMaST3Cfais0hs/eihWQceS7QIDAQAB"
+        }
     },
     {
         "uuid": "FD176DD1-F9A0-4469-B43E-B1764893DD5C",
@@ -19,7 +23,11 @@
         "support_url": "https://stanev.org/abp/",
         "component_id": "coofeapfgmpkchclgdphgpmfhmnplbpn",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAoqpe6QWKketr66AW+hKSxr5qds9gxmU72N20bG/nG8wfbPUdTwEqIG3m5e37Iq1FI0gcQir5UqwZZUgkum5dWJwgCB1SOaVvlZrWZbTbATKFcePswHqAIXMfS+wzMA/Ifoky26dE4k/rs6J/zQEbeXXon/ikjGJ7GxYeHYMBz9DAPQhcUoBlh1C0O0vhvXU+kG5DO4wdIt9W/cXJtv+8OTZ6HiTJw1j0jAliFZI/jhkYB6MW57OBpBYlWJQhMbLbK5opXq6d4ELbjC1amqI1lT3j5bl0g1OpMqL4Jtz6578G79gMJfxE3hA5tL0rGU3vAmwck/jXh7uOOzqetwdBcwIDAQAB",
-        "desc": "Removes advertisements on Bulgarian websites"
+        "desc": "Removes advertisements on Bulgarian websites",
+        "list_text_component": {
+            "component_id": "fdmemomgcgpopbhhmdkdedkphkglhopj",
+            "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0Yrj54S5rhxkhRCeNs0zpXclTFpJUmBKcPIYEbISsmgfGIKwd0GpR0IGxdENuSK4hEzFBpsQLLRcmipEHrDuqeaeaCkyLA7oBsb5REK4nBgsAB7YBekrEQQyOzoEG16RGqcIHw+0ZTppDPmF4Cdidyn9S77U481+W2bEWOp+NpFqPamA5pBaUyXeLgTB6dBRuUPnjjuXwZRF213W8HMI5T0c9HIuLipW+P3F7PhxD84F70dhuCUJ9X/DCjc5CFlWw1UPu3dlHT/sd15qR9glld9I0yGEXgQuPccZCBhnCWLfslaqZhgImmfqI1YBAzOaWED/q1y5hgh/8ru2RjOQ/wIDAQAB"
+        }
     },
     {
         "uuid": "11F62B02-9D1F-4263-A7F8-77D2B55D4594",
@@ -30,7 +38,11 @@
         "support_url": "http://abpchina.org/forum/forum.php",
         "component_id": "llhecljkijgcaalnbfadljdpkpbehakp",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyahWbgHuWAI7CkBdclxOlehPVVGuG8u6bPi1vs016Kbhn9GThEVIP5qzAFQLA3jRrGy5B2nncdaCnibf7BkGsNR7nyQQuXAI2FGk9qCm36ZF7FI/yjtN0S0e6LzSswOcVhTdPnVkxYY6UDuKyzVRxgbF9Yg1aT45NFpJFZKFtKHexnLiY6KlZKV6GhY1jucjo7W77xdpLaspkYbQ69UvDlSA093InAzzikuqBdKvY0FPvC6pgiefqWTMa4M1cZU9IoIiukqrpXQn1tC9PJ8CU4XKCTshaNbpX5wxY10rUl7i/WHNcXCfmCXxKbqRZ1SyH6KiiBrDpSnfKXxrQip4GwIDAQAB",
-        "desc": "Removes advertisements on Chinese websites"
+        "desc": "Removes advertisements on Chinese websites",
+        "list_text_component": {
+            "component_id": "hmnnhojoekmmehfpmeegehbmifiijobb",
+            "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxi6JL3FFNrYHPp90XALlCIOuC0/usN2tZF8oGdXe5v9KFQaNlvV//nJfYOiqyssh08FGsglQqekkUZxKdSsBQ8+7kPyBsrEepH4mWvcWNP68ONMjrY+onYM1csKXSe6aiQ+dN8CuJpcaTD5KJLBSCSGSfYqijkGshFUIHwpj7QnmBkdKzAChnynx88+c6lFIyMnxYjosXtL2Ioi/DFAVpb5z6+smNN1ZSo0lx3NNlCF/7ESN4SbLbCpcYgvs7mKuA4+i3/vQofBHY+YFy4WnGQf3l+QTRNk/uV7J9IKb/11U8i4LqxZ6ila4Ni/6JFzaQBfrvt/Nhy1g2Jkl9oWBNQIDAQAB"
+        }
     },
     {
         "uuid": "CC98E4BA-9257-4386-A1BC-1BBF6980324F",
@@ -41,7 +53,11 @@
         "support_url": "https://github.com/cjx82630/cjxlist",
         "component_id": "llpoppgpcimnmhgehpipdmamalmpfbjd",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAudVtKg3tZbgealGvVzbEL3yP1YWdt6GRDreqy/b3kCce3AZ8WroL8jb6Zj/aapBRCNxBezXzij+b6QiIH/l7sn5Wf5HDs5Vnrx4fDvGRtSLpgP0cSuFGVDx71TQz4X+AnUubOeHskIlJJAT4t4cHWs9c7EAl3ShG7DtvL2qHG2TUfJFqYOMOtQd2qG5H+X9zAUFP/qRHT55gzce8h+SXCsvdK4B8XK1cdvbIykllbGPzZr/TANn9gCtMKxUfk1qFn1uYD6mzg80KJmof8MHbLon6KLMqywcqfwEwvoivxo6f5LkOUjhqDYZEQ5la3h7lFfHKz7fCE7FCww7bQ028lwIDAQAB",
-        "desc": "Removes additional advertisements on Chinese websites, may break some websites"
+        "desc": "Removes additional advertisements on Chinese websites, may break some websites",
+        "list_text_component": {
+            "component_id": "npcnkjiaolpnapjleimicclmdcccoeme",
+            "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsfs3LRQT1thqn9t53KmWtvaKeuBv7mH5ydazOFixM3Uutz83/PZ3Obsvux1/8JHDah6AvxBQtjoZy8jFKZNtqiHXxvkisj5DAL/O/rCwvZBHTXLQqodBxsCpnjAwGG9/Rqw1kOwKAb4hIHy+5Xq1hF8oj3eHD8WnIhvblOMYg6L4gVSCxpJOchPVLs/5K4sovGDxItmsJJqLYrsxtuqvsatQFj+GigrMoOAA3yOPIJDgr4/E+nqD9su5c7+3OPggr42B2+we9rwWiDCLQvXOiV0NKUavlV8P/8AbX0TG4RxTNEUTpGkGkyEzO+bCWV5/Ne+s8ifz9Bw68xW8zaZ22wIDAQAB"
+        }
     },
     {
         "uuid": "92AA0D3B-34AC-4657-9A5C-DBAD339AF8E2",
@@ -52,7 +68,11 @@
         "support_url": "https://github.com/cjx82630/cjxlist",
         "component_id": "lgfeompbgommiobcenmodekodmdajcal",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtAMyjMBZCbqNIuO01ZFJ5iKmcNFuJHXIUqhO9s6j6XnBAfak/OOk4s9k3maXyhaynXVpYATQyRHR0OEpmsQawFgKCmVm1LB68jxJ5Hh1ZITG1UyfznYnozkjBtzdkMGKeuZFBaHo5PPueHVO7yJDHvU3UFW4vCJ01twXiH4y0qaYjL1CPr58J9U0oKxptsfwEC53WcDq6mKtAKRpyxN6vbtFJ5/li2yC0Ms+8Xe3Xv5ovniM/4vNf3Jn1w0jzgrDRcW2VhxpydsH6q7oaR2igIzJ+XG6/k0g29CJhfT85dJNF31TwqvoI+Ju6hjZrEmSHmC7gbY7gN3ak+DbUrQxjwIDAQAB",
-        "desc": "Removes additional advertisements on Chinese websites, may break some websites"
+        "desc": "Removes additional advertisements on Chinese websites, may break some websites",
+        "list_text_component": {
+            "component_id": "fbljdmoohhbifebddjnbbljgencmpjlb",
+            "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnqEZcpRqGk/mgGi5UC2hZSMDJTesTp/trL+T56MTsS2Ld6ktt7NOSoAeUNLjVO2kc840jwtUkgBTO93SOkaC4j4GuVU1mH6hGaGrvAGCEQgcBIIBBsCB1HUUFmWMlaOK/tRrysZ/ugummrhVicxdzYUK370dK2dj13WN68AR4Q2Hvo9gEdbhlG1o0YiGew5zF0BvmqoMK0owZIxGs5Gqq3enGqURU2FtlDBu7Tmfnr/Ep5l1KOSG87Gk2wlYR5KhkX1N6p2/EI167udioZK9CndnxqEIVq+DuYR0obwouV8lzxInZ07ojD5kW3O+WSlcRLCzCaRPFhQMMi7sLLxqzQIDAQAB"
+        }
     },
     {
         "uuid": "7CCB6921-7FDA-4A9B-B70A-12DD0A8F08EA",
@@ -63,7 +83,11 @@
         "support_url": "https://github.com/tomasko126/easylistczechandslovak",
         "component_id": "omkkefoeihpbpebhhbhmjekpnegokpbj",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuYBXbfloR5HddFlg80U8+pf5TqfFJQAf1bL4myp9KfGggwqrjuRzIkPOD8J8IvCp8tWv2f4QK9sAPHhtV6w1cnYX24lKxrQ/lHHAV6/CEcFa+2Yk7cRLKDC10H3r4FMRoCeAy/ruTjVPfIw+GuAfFYl1qYWBNxvW7XXw7cCIIYL4j82YQF6HjsWbTT+QHLCR6h66wvIyVQC9ppjJPxDaEevjt4tohEFAB1NBC+Wxt8H/P5r5ayNcLnb9Ygt75haYL8VWZOJhO/neSTyuidTFG5ox2Ruc6TXP8t0IqpVtiZUDkx1jzUakIHoKNMBc7oz3P/SQ4AanZsIliJobXFeUiQIDAQAB",
-        "desc": "Removes advertisements from Czech and Slovak websites"
+        "desc": "Removes advertisements from Czech and Slovak websites",
+        "list_text_component": {
+            "component_id": "oegebjahecghlckbhkmojgnpcgdeajdi",
+            "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxtk14SdoCDoN+0991kgseVmUETwAVlWN+IHmyX6VM4fd4Jw4eRk5fflxBd4EsQIJQ9hCDxO/jW2YlGvz09Aj45OuxZ/A4T1h8w1IwyEJOc6NvkafVVaR8kvzlYq1sYsuPDiC3ACMx/AvmHTRoLDtJsH64H106ZjvMb5NzeJrhnu37Msc9w2tnmtc8XsX9RzTFnqp0jDeboOYoDiBtEo8DFSzI0CT3ffTMK04yKh/kdnslxTESHyDS69jo0SFRT0yVGH5xlb/N6FIqtB2fROlOrn8jGlr/3iufnvrKylRdMzx1aytHSK17yJiJe+P4YjlH4kjpFMTJAR+/I/SpiDu0QIDAQAB"
+        }
     },
     {
         "uuid": "E71426E7-E898-401C-A195-177945415F38",
@@ -74,7 +98,11 @@
         "support_url": "https://forums.lanik.us/viewforum.php?f=90",
         "component_id": "faknfgalcghekhfggcdikddilkpjbonh",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAu1CpR7Asj+2wl/1vM39WGUrHQ6vT+nuo+XSL7VzTaxW7g7el5lUC2X9MaaynfK7gOblr5Wnf/mjSJJZA57mxogjOCPP8lF0c7sOEgeO5L6hnDGB7sonCEFpHnBEn8VOZDvmqEb++AiXUPBFSnAOt4Mouck5CY80N6Sqbt4cxUBSof/NsGHZiTvCN7fJpW4ajLOtbWhCAmBhdG0VHatBG+Et/Z6yQtxEYQixKQNHJljiq55MzuE2jfGOZ8MAjyQdstF+GGfF6WPqnR5fd1rECK3OsI8zV9OOLPkjKrKEnlMsaMFFFU0T7Ly1UALehlWXtunelzq1mGvVS7vV+5aVR/QIDAQAB",
-        "desc": "Removes advertisements from German websites"
+        "desc": "Removes advertisements from German websites",
+        "list_text_component": {
+            "component_id": "lfmefmifdjlfneapckmpkinmlofjehbp",
+            "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmvTOXmS56FBoh9eAsPUIAFXAYnwmyJC9HgLEtF7D5pkac6WkPAOOeidY+wJ0A2u58hBYw82f/8COkznUUiq7Oubb6+zdJP7lsTYbhN9yoPm+aw1vLucSa2O+O9Xhvp/0bT1bABtdccb9WrRT5HlL+BiHtwwHVZ0KLuX+k1IM6jxWD3DxKk7mnADxIOobODspLGkmduTMzVYygbMKf+0p478Us99aqK8oEMMjTL8IMHfdwFUrTBBbhS8mVkioNUFCEzeXFowhnWeoN6ysjmIcNN2STeVptCBXcaOAYePCrbCDcRzeOTBr4mu4U13Bune87VC+WJkTf+E9BDncTHjGUQIDAQAB"
+        }
     },
     {
         "uuid": "0783DBFD-B5E0-4982-9B4A-711BDDB925B7",
@@ -85,7 +113,11 @@
         "support_url": "https://adblock.ee/",
         "component_id": "fnpjliiiicbbpkfihnggnmobcpppjhlj",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnrl1tavPfozqu7CmqNfVUtZfUlIitbWpFBRn+HVW0oEFUNqAwNlwHqy9QZP88wKvb5N3EJj6NAq6je4ii6nMkDn59teNzGA4m8QSkeOWT6pNm98FZA6HNHPnhnYSG2sT8tpQ8Uyh4ySrxj2ijVM0Hc01WKQ6zjkvZWOuZWllsCejRZmxGOLUUy5mtKhIfHiuleZ7AmKx46AiVFvrpvV5x8G2HKAlF/uDc6LmV0lfXcROt5RlY+kD/sQ6wKcatibpHbLoRHOJx3ac13+pvt85773af0MdrvdCYjxvqn3DJlKw9qqk/B59n+XdTmWcfC9k77Z0teoMM5EBy8G1nGbelwIDAQAB",
-        "desc": "Removes advertisements from Estonian websites"
+        "desc": "Removes advertisements from Estonian websites",
+        "list_text_component": {
+            "component_id": "dcfccddjfmckaigemleendolfmmaaiii",
+            "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAx9d8o+kM4IcgkHERTS82gnn8jdvOaTqJ8YPV+vbiOEzS3ntIawegkGeGB5ZQzxqBdV/v17L1cG9Ze5RvqdHw2eqiRPWREwUw5G3TvvH4NAteGtx8+9xv82s+Vt4skM4bUfvm75uroz4wpAFpCwgpHnR3w8m3cnq4vTog/z4xVd6Z2cR5VSbuH/9S9RoboyLrse95XxMlb4mLDi+vIf9xbLrOYTknw3LQNrSb89+LL90h/XeyDHuHkfeqfAZaJ3g3E50u45nFhgHQQEz4V0vg1jL2PMmQmm01MrZCeC6o3FbTZXHReH0X2EDgaxhi/nq4SSYlPLuCvuHIQAojGu0YFwIDAQAB"
+        }
     },
     {
         "uuid": "AC023D22-AE88-4060-A978-4FEEEC4221693",
@@ -111,7 +143,11 @@
         "support_url": "https://forums.lanik.us/",
         "component_id": "kfhcejhgfapmkapakabicnjhpglajkao",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAs5oODJ9Xh552zkLYW8nkCkzOQ0qBNGbhxf7sXwtJsOgQJ8D+DypeYWal+g63B28OX/xJ3Mwnd4WF0JWeN+i3CxBSidSwCPN6c7/DZF4xUyzpo1uvQnnBL6uYgzBYR6JJ904OVHFEgRM7MIdgve2Z9PyaWvNEEg8I2vqPDyBIu8GAy0UjG9edQLCAgQrmejpxBGXuB6b87FILMryW7ejbUjh39hFhpzu1pmsG1wi4jWX1xzaqUiF5xRPbuBx64BWsAzern4p8XdjH3mXgwJiHItBngcDh1tHKjD7Ke5LmY9gJf9TIXkrBPmiu0SAfVhcwmfj/VuWYa8R06cSaCRZF2QIDAQAB",
-        "desc": "Removes Web annoyances"
+        "desc": "Removes Web annoyances",
+        "list_text_component": {
+            "component_id": "omoaeaghhgmiojkeaemjkpkmelmalbgo",
+            "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAy/xbKx4WIC1LApciemKEs4rUz8MspYGqLzmhQwIsp6qOqMKiYA9pqOtUXx2TYRPkZODISGSsoqvTZ6Uv7Aerq0Bu06UiDy+H4yU0jFZPVDKsMfj9Ky0DAy7ocuetTIps5Aewx5S0S8g9zeI14PluhqsXlTMLQAqkFeUSsML0qHo94Zgx4T1AwHH8IjvsHB1456OCRjxlTICGL0hEwZdEV2rVYWXtkLzEDZ6guPmvEVKZIhey1DG9fXV57SFCLmBC2eTlv0rYDqqgK6KSUeqyAIHV4eiaqIPMgsRFVnE9JD/Q9xrjeAuFc3pslx4YKI+iuXgfa/8jGpPuKqcDX51F/QIDAQAB"
+        }
     },
     {
         "uuid": "7911A1CB-304E-4CDB-ABB3-E2A94A37E4DD",
@@ -122,7 +158,11 @@
         "support_url": "https://forums.lanik.us/",
         "component_id": "jkmfbjpchgojnebkdleeiplnaagomnll",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1COQ5BWnYkWTrXeLhmaFQPHhCGbQ8gXNjd55TQxl2ne07PpSd6We1LeowFPuMrgXyIyhzW+MRxndFYhjMsUyJ34N+GGpDBf1u6zKWkbtprVgFhWDrlzmfuGq0o1SFkOo5bA2h4MhjBIJG55SuM0Bj6hYNtQqqQbcu8wC+L2glP7XtJUawUbZCr2eGFEDxBJA+g4HOgGAhAbgM+1xrL3IMsDTI1QChPjotTRxlUzARVWYMJN/r1Dmu8+pkmsgNfvVcmbLxqPpqhlKV49VtlB0QI0tZMYSIqui5B6qku6XJk7SUt1w0jZ+A5LpcQtDyAnlcnFwi6wqsujhPZ9Y4rr4GQIDAQAB",
-        "desc": "Removes Social Elements"
+        "desc": "Removes Social Elements",
+        "list_text_component": {
+            "component_id": "nbkknaieglghmocpollinelcggiehfco",
+            "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAs6ib1E68QTHuz/TdEn+ck++Okbcf5xDfQjkhpTb59fnjm0rjII6MV3rWLEj5dkOvpAVzDzFCcyC/JJ/SYIY7nFRQl+ptttd1nLWNu7qewFGh2tezwuEMzPlzQr+KK93Yh0dooCC9KniR/0+kpYeGqBC8tBGz8f4KoV+/zTfkD/47pztflCxNJfrAj4P0GDQhvz8lBtnm6Pa7tGOMhksnMsYWRWsYs6uvjsfd+3uYbiCYa7lEMjZZKy7dHg8hPSUeGZo28kTqYFXufH5jY3q7Luk+dQey1+m1X97KLPOtmwaLFCFqWBha5qFMg/mgzczlaphReFUycwrYVjjOICKrYwIDAQAB"
+        }
     },
     {
         "uuid": "2F3DCE16-A19A-493C-A88F-2E110FBD37D6",
@@ -133,7 +173,11 @@
         "support_url": "https://forums.lanik.us/",
         "component_id": "ldbgldhcahahpffloggbbmjllggnkenk",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAm42LAwZhmXBZ23uRGC8btPLv16YUr+9NPd8X4R1TVIMwujFBmAAVDVKR2UT7Ma5FfmdVimr/LxIv3v8DtAlnH5KZCd76Rtq5iYxMlPmCS0QKE42zRK/3u0ezN+/U9xAKHZQviw/Jn+go0biuiEmxzbFlAHNvdqaGtvHwBz24/DzWr+sRYbS2ttk31E1PVWF0un+n4ivTyYRZ6J6DLN3Cl+nPMYrmoyKGVbVLZcWHdftGjs2CGvyIYwlpo/03B1NahA1BrZvEvuL+xuqp68Nx7LAG2MHGeHTFkKYtcqr9gQR+W4EsKrQKCCJ0NEe4VralIVxn0Zi8wOQ4a6127uP7vwIDAQAB",
-        "desc": "Suppress \"switch to app\" notifications and prompts on mobile"
+        "desc": "Suppress \"switch to app\" notifications and prompts on mobile",
+        "list_text_component": {
+            "component_id": "bfpgedeaaibpoidldhjcknekahbikncb",
+            "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA310+gKMk4QUl7K23eSXHDukkg1Ped5At02N11zRHJf52mTFy6jnUgA7vo1hkARNHHJDwI9dSyfYsAtrw9qgo/V9ygDBkgShHyYC7c08pgUkdlciaZepj633yuMyyFK9lo3PEF+f1kOodE/Vq4ybJTChDcotuT5bAi57d1Jiizgv5Rz4W9ZvqsWOVbiclQTY+28wTpfuCLznV7mrx7kvm1D2aQaLaJ2R/936DkXRqUn8Ty9GGGaHqx9HK2JgB5RjwFk0esarZyua0kRB5JwMUGu+TsEiGgDpCbRka3nfxItwhoWGBYPwdapkdUr7l3RdeTCLUWmCBdkpmDMhbrG3ctQIDAQAB"
+        }
     },
     {
         "uuid": "1C6D8556-3400-4358-B9AD-72689D7B2C46",
@@ -144,7 +188,11 @@
         "support_url": "https://github.com/finnish-easylist-addition/finnish-easylist-addition",
         "component_id": "kdcalgmhljnckmnfcboeabeepgnlaemf",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3seBXoyYSdtiqNAIaS5v9jP6Pr8xqgFnZyHknxNsC92fHyRW2nbuwMr78pWA4vPIyV6BFG5jS8k2RXEbWiOKNNsw7nWlfT4QMwkEu4uU1vqxsNDtdc1rdrc69aBegyNOQBS+W6aP1ESHp68AoalYKMHKpc+fi00sdQwYU9Y5oW9q4uRX3baAyuGZjP0xuKN3t+T1QnhbhkldP2WP0ooU/VRMhy2rYoE+W6eQRGrghJJG/wWznz5AiPD9EpPST/hoVWOKVco+12IbdILw7yGX2c65xPcLr6obVR+549QrgxU0W02XxS2lXKGc1NT2Zdl6ugh6XpW1RHVz7SjLIZgifwIDAQAB",
-        "desc": "Removes advertisements from Finnish websites"
+        "desc": "Removes advertisements from Finnish websites",
+        "list_text_component": {
+            "component_id": "afggnigkiebjlahlhcjgjahbhfikcipa",
+            "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwHc3AWJORkPvjY4vthcP1CaLpG5yIga3gADJP4jAfRaqcxQp9f1IIGvtK9+nUerpaomRMTjJYNm1lQk0uq9EAcQjdb1JWl/MOh3OGlhZ3oYLTNqMW/ZbMHrfGgGD33WXCcQElu1nNOHUxJqaFeyOZvI/4LumYrlpADdotoVSJ1pMhrj9iQg+a/GAddBaAGEqYpjF4tNBGPTufmj5L2Grh6Uaue5sLFzH9lNi/VYSlCcXRDrz97EO0tjyNrEQWffuamAAd/ArKDSdjvfAeohGEyTeR5xPq5yysxBQqzryWK17fg9MtS0ZIGBbSyAwT8wctJ9XmpMnGFRL7sXqpYb6eQIDAQAB"
+        }
     },
     {
         "uuid": "9852EFC4-99E4-4F2D-A915-9C3196C7A1DE",
@@ -155,7 +203,11 @@
         "support_url": "https://github.com/AdguardTeam/AdguardFilters#adguard-filters",
         "component_id": "emaecjinaegfkoklcdafkiocjhoeilao",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsbqIWuMS7r2OPXCsIPbbLG1H/d3NM9uzCMscw7R9ZV3TwhygvMOpZrNp4Y4hImy2H+HE0OniCqzuOAaq7+SHXcdHwItvLKtnRmeWgdqxgEdzJ8rZMWnfi+dODTbA4QvxI6itU5of8trDFbLzFqgnEOBk8ZxtjM/M5v3UeYh+EYHSEyHnDSJKbKevlXC931xlbdca0q0Ps3Ln6w/pJFByGbOh212mD/PvwS6jIH3LYjrMVUMefKC/ywn/AAdnwM5mGirm1NflQCJQOpTjIhbRIXBlACfV/hwI1lqfKbFnyr4aPOdg3JcOZZVoyi+ko3rKG3vH9JPWEy24Ys9A3SYpTwIDAQAB",
-        "desc": "Removes advertisements from French websites"
+        "desc": "Removes advertisements from French websites",
+        "list_text_component": {
+            "component_id": "flnkmpokemfpaajmiimmjeiandgoodgg",
+            "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwwUZwUB8V3M17u9iE4xJlqee5tpabVHr4SUZJMdcxUVYi0gPLSQfWHNUR9HqXy4/b92OmPwOHcp1d7gereg8ave7d6syQB3R6xZLM04ESK949zUAzuYGmTSGPgBmC9O09tAw+dmHrHNXi2zKUf/bU0nOXyYtRqPq9UYxIIxq51nqgIqvUdvX2iwVPGVEXOxgKG3zCF8Z4U9tImWYYAq2cb3LbM2+b6w++PsnhwN6XIFFV2KsYVhtrOnzpgE3M+1cI2BT6N9prYIyP55MHfvU7La/VfqgmRVjH+qASJw0kGy1T/c7R4DLPHaND1L0MY7GjwRxAgPct3eTha+weL01vwIDAQAB"
+        }
     },
     {
         "uuid": "6C0F4C7F-969B-48A0-897A-14583015A587",
@@ -166,7 +218,11 @@
         "support_url": "https://github.com/kargig/greek-adblockplus-filter",
         "component_id": "pmgkiiodjlmmpimpmphjhkodjnjfkeke",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4KGRug8Rw1WHk1BPfIdtdw7uwFijUac7jk1lb99lEfSq2uPV2bKCk8lLh/6ahlV/EjSN8mGiFfZIVTDFhuYhVuIO8iETrCZe1ChoI0F8ptHOPQXVPzKUFMpkRqAnH51vqx+3gG78A3+iGfAE+LjerP1j4Jx5jSvTkbN8l+RqKMtjaaL9qRHv3aRQtYB/shGgdxKeOR0f8E6yJ4tIRDHB72bDufN7wbnRoHCNnLkrAPtbIwpWRLKYcOxAB6QqKNCLx/UX/pWpGtyJmMQQBpxQgl3BT8daNp0h4Soc6VPZA9wEIQ5/a/8UpsBT9rwJGj5WdSBPSR8D54aULATPxsienQIDAQAB",
-        "desc": "Removes advertisements from Greek websites"
+        "desc": "Removes advertisements from Greek websites",
+        "list_text_component": {
+            "component_id": "onooookdmjmijocbeafcldnbfiaobhjk",
+            "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAs3sUB/utZpzoNR8aq6FlVWLtCcYC3cl6V6mX1Kg9gUZBCJF4iH3YKlE73lS8zaCO0jnaALUHX2MUFtZvR2qXfHxxiZdlBmGMGfMMqwaTwbRMW0NwhkXfAc7MW3rD0gO0o/FKqhBbc64WefI8TCKwWFSpJCKgBrZK/b3eTWJBg2kv1Zwqd3fB30j4pbi6G8Q+7nryRC8LAY6f+r2MneBoKwJBEXynkq4RJuj6xVaBZAlLoBTn/166tQaoOHf3L9L9CvzpElprKPpC+k3oBTuJqdQXqPafilhpt6ooHnbiBr1LDrV/jHG+YZ0AA5Brjw26ipi5jSn864VsCysGwoLYQwIDAQAB"
+        }
     },
     {
         "uuid": "EDEEE15A-6FA9-4FAC-8CA8-3565508EAAC3",
@@ -177,7 +233,11 @@
         "support_url": "https://github.com/hufilter/hufilter",
         "component_id": "gemncmbgjgcjjepjkindgdhdilnaanlc",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4HNXDsDBPP4b/irxacZMYnaPjNMXS31e11nsFBvN9lFOkuwF3bEk9uEk0fDzocF6GSpXbUE0HVTqfKTTnZfvG9m+C3nT8j6N7BB/wST72s0zXCjSlLWJPGmFnFb/EDkFAGmA9FU4C+j28Obehd94OC9pSqu8DYK4LbMWPmk2fgpO9N3ZV/5Y2Ni69WKJwT72prSMzyVVEAYluCYPQWY93g6dJ9RBtwnHCmdK5TG/bN2q6f50Cw/aJSv8nshSdp+KJK6yi6fBOxF5Xb0Bj+xZGC4K4SW9JjElswaGJi2PX5I11w7xC24jNaW6BUHcJ6IXudIVmBFQxWWxkMVwfgqNlwIDAQAB",
-        "desc": "Removes advertisements from Hungarian websites"
+        "desc": "Removes advertisements from Hungarian websites",
+        "list_text_component": {
+            "component_id": "ldnolaledjfkfgpjkbkcfjiaejeeanmh",
+            "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA7xknL/MMlSEoLkHDXwyP7S9c2e9q2bYvfBeaA0ZOQG4O3hB0AInjki37iHINkQX/UAEprDDqwNOO0Xp/pWBWItrFYkgPmgfzoaMZ7PnwUiA7/+9Z+JoKJcqJTWI7VlVmUpeclWcL+hqdhcjVGdGK4Y8wupADUpasqsG0mjwlpQ4ur0+G6qJIvbYB95L6Jk1OjwE89RjxYQNPw0cb0bxWUDZ1uLSJHe6eMvMH4P6V8ihwltHG0FpZ6B9U2uV6r1KeTWCbfsWJJLPmzCW861/lSJtOSBynVcsS8m0vD+UHFZn0IbqoLOJZpqvtZCTjl5pC6WOY1TP39J5WoLJtXXO0mwIDAQAB"
+        }
     },
     {
         "uuid": "93123971-5AE6-47BA-93EA-BE1E4682E2B6",
@@ -188,7 +248,11 @@
         "support_url": "https://github.com/heradhis/indonesianadblockrules",
         "component_id": "egooomckhdgnfbpofhkbhbkiejaihdll",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAptA5jVa5JkYI2jt905om4OLSHGahwgS7tu7GG0sk1YNafOo4ajKrN96Kxj0fgwGrJPhU1UiTDmrgLTZSbuC3hAscbfhuakVNo1pyFfSAVoLWSrOq5l4k6zZK+y1ahxdyJvlbz06RWE6OhIqExxGqLyMjEknkPGxBVO0cKcYHiGYUxvVPxQOg+9fGieXMlSGs/L7Mty1oJOoZ4JcPIFeSvQ5ax48E7l+yAW6psNpPqRAZ5fm7hhZXjd5+3cfXXIMStgX3X0MUHjx2KpYlv3NxMjaZQOAZiuZ3W/H7VWnV7V/ScJ9Eb+e6iG4XS15f7vFQu4zPy4UTYOl6gXnIGWGmsQIDAQAB",
-        "desc": "Removes advertisements from Indonesian websites"
+        "desc": "Removes advertisements from Indonesian websites",
+        "list_text_component": {
+            "component_id": "olkjbfppmeijhkjhjjmfdbloighaigmh",
+            "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxNZ6zkktNhRLBkb0qCtQqkqt8mNTapW+0dO8s23+cjHz/pcVHOb5dIWvuF1OtyZOYFojIhx6GmTNPQ/RtwMO5TSwUbLQTHmN/n+e2/kalV0OO21SAXOG4C7myNGa3FClPRTY9vGmGLCtMGkak5I70CbaLrjemO27gxrWWi2C1vfYHzzCkt3wriY7ZE8Xo2SGZSJ2z52Q/xMJVviF2xXXnL56ZvpDifoM3KYMacXPMa9nzOvZ6KHXmmqHKFNl59LmujK1SH2p8sPbz7FykXVgfZedU8Ul7qfLWwGUcliLlALE6X0lLvEtiX60nz3dZIrvZAfagsjayDsCydf0lQ79ZwIDAQAB"
+        }
     },
     {
         "uuid": "4C07DB6B-6377-4347-836D-68702CF1494A",
@@ -199,7 +263,11 @@
         "support_url": "https://www.fanboy.co.nz/filters.html",
         "component_id": "jnnbjhbkmgggeoplhadmppaeddmeapla",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1KcZJ8dK2ANtw8x19l0g1i2sSsg/G6AJNLORsw+Uz9g6sx7pUJo8TpjyITiwO366C6q/I2KwFpuc0NgGvWs6nLMEX6yaGO8tnrza36Dj7GFTQA9+H0TQxuZdcOfZqP8UakA6exGOl0anzAt/HQB1Gf6ipKilS0M4PAnPwlVaTRmdKxQwqHQrpfWSiKRB3MBG/OT48y9SXKToP+NAIIfVRC7TxPVJ0zIu41UDfU3Mx6zKOBcRfTnhmUT9XIEv2lAfRDyEDXTGg3nSNluZM4Bu4iQKpxj+x7oZDpQMkrpVBZdjpIRMPiD6aMKCo3GULoH15Fb7re5RZLJIxcu0+B8lPwIDAQAB",
-        "desc": "Removes advertisements from Hindi websites"
+        "desc": "Removes advertisements from Hindi websites",
+        "list_text_component": {
+            "component_id": "femdbljnkmindcakmnbjhfefepeaicnm",
+            "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvr/tGn/LAkKrRrt9PVmtyFvKMhSEVj/OuUsD3Jorj+U3TU06Akg8YkGg08rrfjuZjFTtBoniCgtQsnpIuCaRhN/2u95EkGxsS92932YjQQUDMw2chAWaaFKJI1bFSIvvuPAK1lT9RuW/Aa/rpOjDpAZiszVoVMu+ZGNvkheBVm1HbU5rPB24x2kdayzH87wcJS9GxApGa29cXUNUmCZw7w0JNqd76/i86SZBdjXtlPQz1LynLTGyyCUC2sqlcn+lVNVTkGA86EQwM/GTrknGaqyArIoeJMgoZ2WCOOozz0RO6RDPbDHemLE/9+ROHxFwtjhiXbSR+8bbUlKQI2THvwIDAQAB"
+        }
     },
     {
         "uuid": "C3C2F394-D7BB-4BC2-9793-E0F13B2B5971",
@@ -210,7 +278,11 @@
         "support_url": "https://github.com/MasterKia/PersianBlocker",
         "component_id": "dbcccdegkijbppmeaihneimbghfghkdl",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAm3AZE2ne7R55X2j6RxAQHAZKl1hNPgwLOFsYpfAJ6m0uXmKJspguWxatJ9jDBbYLmtXnwX2WORILq1+r4kFtTcN8GNYe7/7o5yDLucI/W9d2vCjmEg95v50MzVQZSwd2gNZVZtL1s0S6pBwX0zI+6kHIFr2xqGV/FNE8L75f30rriQ0xKmenI1OWjyn8gNqIp4mKZW6XxkMRRS9+e0ynDi4ysQA9Ub5YHJxm0t62eqTmIyemgRhP6Rdbi0+GXbqFPjDfC26rtD3wy5f3aYL1V+2ADpdDyCeNlwCH7+vC7LWujqNTgK8wVJ4eH5VbUKC1e9cm/T57OsHJMDC5fbUuswIDAQAB",
-        "desc": "Removes advertisements from Persian websites"
+        "desc": "Removes advertisements from Persian websites",
+        "list_text_component": {
+            "component_id": "keclkbppmfihehggeadflldbjpolcpgf",
+            "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArAhgRAugxeTTvhXNSRQJ9nE1mmECE9i6HgJjNhyG/XXIKWSzCcbu5wmjOPN11iLjNVHdLZMcKnAqgFbieAVxVRFJdWG6V//E5QZRjZ90g+OCgE7wx7W3BoJUynOWirGuaJUyYv8T6qvLqeYm6RtPMgrfZGxUJ9+PDWCtz0e0St09RtXdPhr4Ft2Yk41xda8D40rzgr+tnNo1FwSdysMbLA5xjD7pqSVNR0b/ivFt8S5o6klEifZywqlmNcfpeLFqhBBfNGGr6xIy0EGxo9HNjdQ5lrn9Cx/bL9kaKiYKuGOsERkSNfrGipnDMZqtTGSY1ECEXaY4IiXVkqYJ798egQIDAQAB"
+        }
     },
     {
         "uuid": "48796273-E783-431E-B864-44D3DCEA66DC",
@@ -221,7 +293,11 @@
         "support_url": "https://adblock.gardar.net/",
         "component_id": "njhlaafgablgnekjaodhgbaomabjibaf",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqSwaNKhg90HCheaJu3sHocbZUjXDs90I0OmijNkDeS291wUjvXAm5YqhNE8aZmPSMVZBjBCwKXrrtTOkMA1b1uBqJ2P83fCZsgNZWbGTD8MorMrU6vyqkWCqLRc+bTTUgzAd55ckUJ/M+HVnjo6QfqUuB3kVzjpwJorQQZUYOLcgDY/Q5/tbrXI5+OGVxAb21pmnk8JHXNNWB2NvpA2o3p0ke/7WEoUH24l91ndOkXkN87eO8rSysl07Eq7gshbednYYiCxRPjuX0aPqbXMYNWXa5NdvIXFJcD2xV/l/QvXRYl+7Ca1igSXaiKc5eJyKSRqY4lf2vG0XCH6VZVxZuQIDAQAB",
-        "desc": "Removes advertisements from Icelandic websites"
+        "desc": "Removes advertisements from Icelandic websites",
+        "list_text_component": {
+            "component_id": "oimegboipnkgekgoccmlljjlhhbjaoil",
+            "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA62u5aa9kHm8s001ehhl+tuEE0bSSUxxBPfpSWC7Xr9zwObVpq63bSUAQqgqy0RW4RIq9X2etSmtpYryr10FglhV3TvMhZ/JxAX9VcPolrgG+tdMO+000+S5T5N/qpgZB1IycedaHNQ2NEFBSZEU7wqTIqHdYjAerkX8yC13Qg89FxU73Ygkq+1hQl1ZUr18f2gU6WpG5Nv1hpwwNQKJ5mn9K4d9uE2W7croqFANvEcvG6teAnw2JCWi42uabN8Ec35nff2r3BPCryCuAx3bsInasbDHNFlww6HXHBVfBr88y8v4hursSGmKShSFBMM2IGcRaF7Sia9fWGyQkBjiE7wIDAQAB"
+        }
     },
     {
         "uuid": "85F65E06-D7DA-4144-B6A5-E1AA965D1E47",
@@ -232,7 +308,11 @@
         "support_url": "https://github.com/easylist/EasyListHebrew",
         "component_id": "hjeidaaocognlgpdkfeenmiefipcffbo",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAoUnmZ/fnWAGhAywLBs5IX0OMxK6LOwtjljcwEkt8QD7ZKBekxq+MDrUuRPzav3ky9IyREhXe9F4UWBKPDD8ZQXZ57WQAAMAp3IxbgdAsTqqTEEReUVx+pzjl8lxdp7xEG2gpuM5wq7bjn4zJ3kcdj3vx7bec/YbYf4fV0brQPWghKf2sh3mHXOVh68wEFXYBvcWkGXfuBoRbB9WLflqZYRk3GrLllwBLn1Ag6iuKucvoyv7N23qXKIjqAhyKPmHx4l9w/v2c1pc3NB1af2xvtRWaQp19N98QouFFx5MwAI9+jR77Eox6QvRwA+L9CFkYlDTvT/aS3q+Zb1QH/8AE4QIDAQAB",
-        "desc": "Removes advertisements from Hewbrew websites"
+        "desc": "Removes advertisements from Hebrew websites",
+        "list_text_component": {
+            "component_id": "kdakdkdknmkkafefhcbngpinlfoopoej",
+            "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA6OM0Ert1wGZ5bOxBO4Z8qikIwBWLZpXnL4Fy8zhu1NOfCODMHxv4WdEZLaQrSgpInAeHi7u0d0doNrBx96wwRJmm4Ng+HlP/dHtihNGWz1yAcrRoKzqQzwsb1Ty+4TPeKRcJEf1JJv7aveb4s3Z80Oo3C0UftdCDx/R7cXWkGqFB6I5CmtpcWWcLtLfb0sIKl3HE3rfDPclqK4sM46OOi7iGAlfk9RVcWsVv6on0yZHInT2T0QCWwvS2KnwuntARJ0jmIoQf8MrrfwwuchFrqyZ3+D0pZzg3NIXLSQSoVKySAOAafTE+NIQzElT9pVJPfFkJ/1kYRUGoIuc/OlnN8QIDAQAB"
+        }
     },
     {
         "uuid": "AB1A661D-E946-4F29-B47F-CA3885F6A9F7",
@@ -243,7 +323,11 @@
         "support_url": "https://forums.lanik.us/viewforum.php?f=96",
         "component_id": "nkmllpnhpfieajahfpfmjneipnddhimi",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAurn1cJrIcCa8P7hjGex+OUHi19PRxmjJ5DuQlMAeIaKibwaQOZEPXSvD+O+xgxHZJs1o2DE8zfj6yrAmDfu9+/T0ArT2RWuopDMEfaKdeG0ylHP62WJC+KGUhCiTNmLyPxbU9AiwydVyFOam8vs4Tr+9I3lYKVeClQrtDRM34BTOAsuHRjiuIKoC0jDC2kc+BAsAbzhIdrkEDGD+qx0rCRnGL6c8xODe2PLKSkCSIsqOk44eYOkBqQd0SgmCvQjXS2XczMDNuV7DCZofErsy2iEv/2kzhkkN8GFwbRkYGN9LuK8rtekE34AvZKRHS6e/pHjUCYJb/2xv6elC+VLsJwIDAQAB",
-        "desc": "Removes advertisements from Italian websites"
+        "desc": "Removes advertisements from Italian websites",
+        "list_text_component": {
+            "component_id": "eaidcpcfnepdmmhbglgjhpjdfodkdcki",
+            "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA6srtCOWjPWh8AiCrnjcJd9iFwmhs+5VMfnfaQnK5PeK1//Hr0xlrS9S6Q7AHlE3O7fBFS9EkBGXAXPeqNpXAuE1wKkzmKkOWRT2mCWQcc07sbIUjyXaQL6UIJYTQREJEZzif+beXopscv/ALsJkbTcMWaCbqrTx7SHVlIdkf44B4VccYsp99vhDg5pzhMgDtq+f2ni3jzM0EmECyp9lJefqVEvg1FXNLI3Z0DxkYr1izYCbH3X9NNj+xs7OFz+5eXwus/Ikt9JRtYush7Kr50O7fD/ouvdB/gpCXsvqDW1F3x97ysRZwEQTgioLlVnMs4DN0T0TGoGULr7QkmpzigQIDAQAB"
+        }
     },
     {
         "uuid": "A0E9F361-A01F-4C0E-A52D-2977A1AD4BFB",
@@ -254,7 +338,11 @@
         "support_url": "https://xfiles.noads.it/",
         "component_id": "agfanagdjcijocanbeednbhclejcjlfo",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsorIQuFuMI5OaGYaYTu6+kZC4j3qPoWRoD7F9GS0IJC+VEk3XQ7UTsRXlrIxP9obmC7+pByP6hknBUzvKKS9I1v2voIqjUoydWOozbfoVoRhTLN3UiDnoDueXqXiv1MGLzY/ZcsxsxAlIiTcE7+/KdM6pJ72Mn/aLKU3escIJ5E5qOHJOFDLW9587JeWOzexaCOrtiZMclE0KWbUi7qB3Bz3auF6piSzoNGeI1NMwHSSAwhDOQ3UK09aqRKhyfBq6ugrrYyRAr3FWqmMBWkiTsr6SzrbQg3wcGbD+GDvoQmqVf8dH/WYG+srR6PyJdYH5mOQs6Yg+nu1gvwQ46Z74QIDAQAB",
-        "desc": "Removes additional advertisements from Italian websites, may break some websites"
+        "desc": "Removes additional advertisements from Italian websites, may break some websites",
+        "list_text_component": {
+            "component_id": "njbfmhgmihdjfgecgfhgknkinndnojgf",
+            "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA85EG3eFmZn/VmRqgmfOzcqGNbCUIsj2ZKu/GfKG1cYz6N1Qyadmmx1slJhc3wqaSav9U15SaktcELk9d2dSXEsQPStluf2Vrw6ClqgTUmcxkjtni8PY8KRLd6ZKw1mUO29NonN7B8qEUWAiObqPP6dg25vSAoj1NXgnkq7WlA/JMZx+rijviam2Ya0HdXoUIOeuzYhNQERjH2R/Va2EDT+LsPXSjW3qGxfBabQfMuFFhjyTIvK5vRMNwoxTV1q7Z0o/zdB9HtXZlEWpkEEBiWFZo6F+4tUBopsCSICbSqbwAoJemo1O0BvR2suf+yIxuwbWMv4y36AtFBbhT4tiCqwIDAQAB"
+        }
     },
     {
         "uuid": "03F91310-9244-40FA-BCF6-DA31B832F34D",
@@ -265,7 +353,11 @@
         "support_url": "https://github.com/AdguardTeam/AdguardFilters",
         "component_id": "ghnjmapememheddlfgmklijahiofgkea",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsOoGwN4i751gHi1QmHMkFZCXFPseO/Q8qKOQViZI7p6THKqF1G3uHNxh8NjwKfsdcJLyZbnWx7BvDeyUw3K9hqWw4Iq6C0Ta1YEqEJFhcltV7J7aCMPJHdjZk5rpya9eXTWX1hfIYOvujPisKuwMNUmnlpaeWThihf4twu9BUn/X6+jcaqVaQ73q5TLS5vp13A9q2qSbEa79f/uUT8oKzN4S/GorQ6faS4bOl3iHuCT9abVXdy80WSut4bBERKgbc+0aJvi1dhpbCeM4DxVViM2ZccKvxSpyx4NvWj56dNKqFLvzoA4/Chz1udxifIXUHh0701s1Y4fLpY0wWP0uXQIDAQAB",
-        "desc": "Removes advertisements from Japanese websites"
+        "desc": "Removes advertisements from Japanese websites",
+        "list_text_component": {
+            "component_id": "llgjaaddopeckcifdceaaadmemagkepi",
+            "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAquaOTeP8r+FbVSg04QHQYQGU3NxdQNsbC3+K7GtAB7p1YnrbxD3YEUKYI357Tasm7URCWTtRGXIkOIxUv4hLL8JNUNKdROaCruKPdpDNwTJshWzPfgKo/ZHTYyduUUP1w4o1CfqQRw7FpekOebbTsm62yAEPe+RXxHfyu2YQ+njCX7IPvI0or2I3i53HCWz+fxaTenpcEn38TlkwLUdlRR183v+e6kfjDvo5HgvNQJsFFC9MM++yd8KdZrDuombSyFIUTzuP43yixeMLBeZ8IbGGpC+en8CA9OgekVhsIYWRbnRGzZmspgZ2Bq/SOuIqf0fLMgwLmNbgD4h1SIbmKwIDAQAB"
+        }
     },
     {
         "uuid": "45B3ED40-C607-454F-A623-195FDD084637",
@@ -276,7 +368,11 @@
         "support_url": "https://github.com/yous/YousList",
         "component_id": "djhjpnilfflibdflbkgapjfldapkjcgl",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAux80m8cYDEXwq+nMwmui6NCO9SFAdcGly5eq4uGEIQNB1R6Tr9JMqosHLZ4PnaUJqJwFfLWfmxzXj3q0DIpqqpdSq/jTYT/MvOldC+VQFO+NIjXhtysh4Z5F0BzlsQx/leMnV6yoyQjBX53n9cl3BvQK/EdbuQSDiNqX2TSVLm7hnr7Vf8m4XYRSCSJybY/1Tk3Cqgqywlkr+YN58L1/txXCQ9LJ5SxJ9I56TxqA1uT97hBmQikvnopuLh1SovDfjtCZwWwaGDD4ujW+Qaeh9dRrojS47iwG/Twu1xbb7ra8cn8BxdzsPjUSSurpPz/9sUooYOGJO44p7u77sxeTXQIDAQAB",
-        "desc": "Removes advertisements from Korean websites"
+        "desc": "Removes advertisements from Korean websites",
+        "list_text_component": {
+            "component_id": "gdlpebjigadbdpjpfpdbmogebilelnbh",
+            "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA32WAaxLDPB/tRWpUQmFYskJQWzqfKz+MdTQGrvHbvCE2lo8ssU5BW/61oIBENfU7NXslKICOMREIU9JA1/I/ew9bF4X1VExdqaLkzwVPmTOKwamv3VNnNXydQY0S0MwexZ6lL8Dm++/T/mmo3IDY3AMfUX51NrDmNqJk5HKsAVJMDqGh5XGuySsJk4iZOeJiqheiUB7JP7JXaWBxjh9wO1W4/wp5oxcIN9V8LSowLGzG5e5MTH4VHjWkipLd4zkwYnsEC0pK+08i0WwEUEdGVFtqKTBRt/vCpg23OqrOIRRiTZaa+tUAy1YbtNUanvr3ioreTuYwbCx04MOLss904wIDAQAB"
+        }
     },
     {
         "uuid": "51260D6E-28F8-4EEC-B76D-3046DADC27C9",
@@ -287,7 +383,11 @@
         "support_url": "https://forums.lanik.us/",
         "component_id": "oidcknjcjepjgfpammgdalpnjefekhge",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvCOljWKWLWfq/k/BE9gIZtI1MstmG+NcgGBGAP0R7xgaUMU5phdSbQf83Zt9ctwDRpisHWlGS6o+tk93zMIoJVj6RMQ2Zee6QPAKAGgwuCXF7A/ciI3lRyX7ts49XV8GAbasu1mBHntz+GpmOVmoiRxcDMUDDEqsSXgckCM9HkYvIyHQWyEgeulKdhQ2HoCptD2Wgmws6NzRTgQ94+DHu2o6J4MsG74h7L/cG3XB8WQNuqlpjjFIQTXftuUWDSkyR3tlmMxGN1PXAH6RZBNmwQTwdgrOAqEup82dWaO3BqoYGZdYeRaUGRc73iPdvvjZb1tvmqLdVSq7Ur1XJjJJTwIDAQAB",
-        "desc": "Removes additional advertisements from Korean websites, may break some websites"
+        "desc": "Removes additional advertisements from Korean websites, may break some websites",
+        "list_text_component": {
+            "component_id": "iihfaghdnbilkdhmmnnkebhodfgeaopd",
+            "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsS7LwpmM6baZKPgEVYsRiLZAV6TpvdwRGAoXbprVO05/uSySDPuRvmQt/76oODglOIF3ZJcru+YJE/nCVrXApHbNR8Y+LWsbKf33Ae+Ljw3GuzYOnnIpH6hsgJYGShCWya/5np3pzLpDJgYKdg8TFdnjmf5xQ7h30xek3qAHPzT0gUfa/GKlIiTo0yyMz0qT3evxlDOtJhRK/zC30qnzQuFqMmu0g58klp4XGZ1E1l1CaY7dY3iOSYZnjEcsK3ooKwpnUGi5JICJw7bUI4RxiDX5DL72SOqS4NZSlOvX8nkMZWW/iuYkYckQD3Ya/bCOZlDaZjKoQDHAyXE0zeP5hQIDAQAB"
+        }
     },
     {
         "uuid": "4E8B1A63-DEBE-4B8B-AD78-3811C632B353",
@@ -298,7 +398,11 @@
         "support_url": "https://github.com/EasyList-Lithuania/easylist_lithuania",
         "component_id": "dkbmlhggeoegbkimcafbfhjibdknflnj",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqCK9nqZcPjszbCmHXHMyLgwzSJGFHLIRKGF/QP4GRhdCh+gsiE4Y317mNx9Q0ogbrvsmYGzI7z+Vzfh0BSOEYVs3bl1dCNENPyf+f8kXWySoHY1/u8jMyeJsIPFrIhzjoypGYgqmjFTSnTAYhTPKv6fQ6KHUsNn/5WdKis1h/yPQSFWw7PX7wJubyD3UsE6mtWegpR9sv8mJdaFGvCnTvxm0NRxuAlP+3yINKmnTal82KpPTXh3o4ehNUsGQb8ibcMT0jFmq7VcD53gxojmta/AhBjP1LmByPkUMe8yCYKpnW3zMg1LS4JNcWiS8H2ApUUSW/9wUKMZI+3gidakP2QIDAQAB",
-        "desc": "Removes advertisements from Lithuanian websites"
+        "desc": "Removes advertisements from Lithuanian websites",
+        "list_text_component": {
+            "component_id": "fmddkdeghohhfoglgdpkhlnfgmmffklg",
+            "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAlW+uDh7W9fxDMhekhHT+KeeAnf/I9SHZWNjpXeZ0bdhEqi8BxJ8UQFAABdKp0ZIg5mkurvx8/y3DYXrnM4z2Dd21UDmsweEVsS342RNZKtmxo9QFg/Zi50wwMcaVkGo7l3D/hPHb0Ss+M7y+E4bx9KkilUw786DPSvW1Z8jPKrx60+em/7QluU1LtkLjMXDocgG7bSvx9XV5thcCszXOGgoDVGlosD2gTVljXmtahVFUU2Hh42Iw24bQRc+PFYeqp8f08M7v7G0jmCWcehXWlnrr1wbmqCQvcLr33M9E7z3LisVoVOW+Nx6upsC8MgNDtbgHgub0ZAPm9WemZ2wfJwIDAQAB"
+        }
     },
     {
         "uuid": "15B64333-BAF9-4B77-ADC8-935433CD6F4C",
@@ -309,7 +413,11 @@
         "support_url": "https://github.com/Latvian-List/adblock-latvian",
         "component_id": "hmabmnondepbfogenlfklniehjedmicd",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAst1posKDpKt3WLU07CziowQnBKYXzH2i/sDdJfMuTcKSNQvn9dxbHVLhg8Ih7NmN6SSJTRgb2PughdVNPXqlT3/jGioDC0gN8kBrBoN2YWgIW2wdvTCPvBOfwTOhGueQY6AtE7zD/3m9v6Wfcw07Rj84Su0qI1Zadmq2pBWo5z82vOAI2yV83YGDbnyK1JaFeLToYQmj+bMEojoZ4Lk4PbFmopVh1GkeOdCKtVN2NTIy43N/w0tS0wlLxjwTyZ6RIcK3VOhQXBqcpwKpKm/4WDksTvNRLZ8e526z/nqaasM/meS22hURh6NPtIOdy6/TspTzFPiRdj2xgNfQZ9oRxwIDAQAB",
-        "desc": "Removes advertisements from Latvian websites"
+        "desc": "Removes advertisements from Latvian websites",
+        "list_text_component": {
+            "component_id": "hkeaopcnlcfbmbogejmbipnnopjlpiph",
+            "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzKJQ+ZqjJLJ6sBvIhxOmFV/jUJ2qIdEwTjvNd/zb5jmqiYhFTamZph1qoov3S7Ob6oFZIrluwhYP3i6koTOLFMRDpgV5m6K0xtAZyTxJn/YrEi0kqJ1DY+v9OOrtMOSZTF+Y5GkYsrG1F28KQm+pxJ9BVreGBx93Tis3CbGTGorPHbKe74IyYtWHEJ7azFhp7O7bLAMZfO3j/g7XRK4m+o2pW7pmd+YVdixQOblWK6ha6Ircowo8M/LwlQ1Z7EAmpXSUzEk4cGF6IlekyEou4SmcR+eNZcGpTc+KRNGe+gyZVkd8HuVlG4fphFQRGkNxl9/7ttZLohO5CGJQj5srVwIDAQAB"
+        }
     },
     {
         "uuid": "9D644676-4784-4982-B94D-C9AB19098D2A",
@@ -320,7 +428,11 @@
         "support_url": "https://forums.lanik.us/viewforum.php?f=100",
         "component_id": "fbmjnabmpmfnfknjmbegjmjigmelggmf",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqqfwmNS4XOq9pWC3XSMt5WcqoKaj3lRpYAwZKTP+6DwA9pG+Zw+0iWC95riSLjqPgX+0d2cZaqjinuNn3mUMOeGdbwSIeRLE50J5J/dMmkg5YO09orZKLBjMfJG5IDgfXdZLSJtmzKC4Xj2y6KSuQ7N0Sg5f1Ecc19nFbcFazCaIhKvcoA84J7Twf2IoCDuPMsGplgZCBtFQkKeqILaVhJZeD0my6pdC2KJREbM3eRnntE44O0sbmemCfHs9BV50hVb913zGDZ379eTqg3mPjvH+VnY+7RvjVPayJP4+51zRJYKi18W7KMry3sj4ZZ3EyNKmbwlGQOzAyd/Qtj4I3wIDAQAB",
-        "desc": "Removes advertisements from Dutch websites"
+        "desc": "Removes advertisements from Dutch websites",
+        "list_text_component": {
+            "component_id": "oojedkppeblkjkcdlmlahnhndjmbicoi",
+            "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA258rAhhideU4koO8wXSn+mgxg+PBAv3+4fYEgf8ezDIOb0zXikwunPGMUCX1Z7dpyqhzYjtYFZvdPlXWJglEA4mpRpQjb5MUKALRC5oQopDhQnZlwhL5YtPYEo60yisqAEFrBm+ngdchqI/41AZuAqY0eNu6in5wxoW2norZigFMovXDWGSEOt63cpXg9KjcwN02cH26k2DO2jLLUFkjRCy6v1XKFufBMoGc6T1MB5wzonFeh1uZvJHJV/M6P+NZuRG4F6SimF365Uq11bvgLzE49tIWVXdkt5MxPzJESr/+r6M+AfGK5nt5tyWDRAW5Wrp74ae2T7p3e0grkqNeuwIDAQAB"
+        }
     },
     {
         "uuid": "8BEDBAA8-4FE2-4FEA-82F2-81B8124A4A74",
@@ -331,7 +443,11 @@
         "support_url": "https://github.com/DandelionSprout/adfilt/issues",
         "component_id": "kcffflkhcncgnbmgdhcgjfogpoacfied",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAocZlfkzlHWHXKsez5tmC4fFn4sJcjP67IlACrJIla8GgWQ6ipDCntH6Qq9zACQeePL5jocESzqh9vzdFdgY66puCk8dnLz3VOciDMLABwwf76runOrWVEEBUyDK+tq07tdHRz7V7QohRuvRoqRvdnXdbi/mcZGApuF+UjXVhs7OVGZSVsS9nriFkm1RF6BAv4/9wB0XhfCODaX/5bI34V1TbteN6d2iBKrDD7e7RxJCFBz9uCmHjR+yrxyZFBxDkgcH9FrXm+7tOGXuLmJljZ6frazp2Eg75aDLkC1O3FQgYqUP5H0Kdyexi6HmizYpQ4hW1Zhlv2hqeArAs42s1XwIDAQAB",
-        "desc": "Removes advertisements from Norwegian, Danish and Icelandic websites"
+        "desc": "Removes advertisements from Norwegian, Danish and Icelandic websites",
+        "list_text_component": {
+            "component_id": "kjdbffhfijkonelaglifggkchhmgmeli",
+            "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAr4vfQONxziLBVdFe1dHEjn5Ut+TcO62xyF0yfF9MVZqnOq00SNzyhUbXyzU6HxSzLU/eMkmTeIBJ3h+f4f3TPirs6s+EtqJkZ8R4er5aHhexGLKUt3uhkLv1IYYw9JimsfxMQOKWtz1O2MmbJJ5HcQ1jQQ613x6SOWtPpkeH0FdcwSiV83DJMVUjVFNwBdl2zjqulQP1M6geNt6eSNN++p2oB+K5kfpMAPopRuRfhZ1spDSm65qfBGGYfgPl6FanfFpTMm/U/vC76KeoMW/xpQw3s1TQeQDY3QywBWasUxmxiJN0DRsVapCAFqT0dXQ+Q3GCCCGPSB1+EUusnSJpgQIDAQAB"
+        }
     },
     {
         "uuid": "BF9234EB-4CB7-4CED-9FCB-F1FD31B0666C",
@@ -342,7 +458,11 @@
         "support_url": "https://github.com/MajkiIT/polish-ads-filter/issues",
         "component_id": "paoecjnjjbclkgbempaeemcbeldldlbo",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsUqWP6CeMx79UyZ3GZ1XcBGexIgml00sB286wZ7dJsfqG7oI0EGRoqrDeRreYcOTl+HvXsRJvR1FfkKJzD5svdhR4mn4lI+FXUDCvgEZ9CFa0YfASuoTIrdZtG74Twu2ai52ZJzrQ9ike97bdwzuZo+uymw26S+5/+IQbriIYoxEbJd7EryZuo+W65LdSat/NOKKf1QnVTIOoqMrXiewRYywnmZATfDIi0uKXuQfF15lbNBkQllmPH1xlMkz2WnvSvqI4HKPAmEFJWVUkiNhGKFZkTk1+88CgGGPVsKllxLaDOD+j8Kb0+h44RxObHTF/vFkfh8FfzujFj3HtevjCQIDAQAB",
-        "desc": "Removes advertisements from Polish websites"
+        "desc": "Removes advertisements from Polish websites",
+        "list_text_component": {
+            "component_id": "ngcohbdfildjnmfnicgdipopmlhdcokg",
+            "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzI7s+FWv8M/Nr+OdXIooICxtv+Q1TS/gpN32+ToVeFHuaQwWZ+O+aN95D9ZRrRb1/mQQW6EkY9Ce5LxUjosw0C9bF0yyB5AEZ+lJQIelrY2c9AvEK8wcNiI/T0GTEcpB0KnOI0tMhfVZZnUj3piiqUZHvXKvcuA6bPoaalPy260o7npU53UZjtMf8RGEigECWqaEMLqYRq4j7xhX8Y8lMeqGfw9Ff3jC2LUSZamTHL2lSdCzrlYN4LMHnAIawR3HSll295BEwo+OBj5vjD4JpZ7NxapUPnXw8k/CGfsKPomQwuBb/JWEGBsgaw+5EFPVKz69MoqR90p6hdZptQZJYQIDAQAB"
+        }
     },
     {
         "uuid": "867EF333-8336-455C-9CC6-98749AEE69E4",
@@ -353,7 +473,11 @@
         "support_url": "https://github.com/olegwukr/polish-privacy-filters/issues",
         "component_id": "baophminpaegfihdcekehejfhpmjimle",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApX6GHwd6ZsPNk4iomzHF6fb69FJcVyRNTQc3X/LlDuEXERJ/eZzDVMn2pCm2CTCXQHweQWqBkC/20FkjniwGb9LSjzP5jdcDCFmSwaFWdiM7xG+BfMFP+XDJtjOlqirWESi6dzwnQ5pKQDpNCblMBuuhT1WyDLtHODwbNJs/jILdSAapW8eQApQ/iCGidYPbPvPL53bq+u45UXXljillsJTbGV8vu2VVhf9/fL5McKu7uX6xR2i4WR2x1hQYMYu5rnFIrDNWGIn4CNDodO22nyBBjznGfQ8XVp558s5tC+v+12hY6HJW4CWJ3Oes+PXuLPDUwYuJKkuncfADk49oVQIDAQAB",
-        "desc": "Defuses anti-adblock from Polish websites"
+        "desc": "Defuses anti-adblock from Polish websites",
+        "list_text_component": {
+            "component_id": "beeceepafhbchnbfdkfalfipoancnjkm",
+            "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuvdYUaLF2iI9loRQjDLZelATqaMso9wPX0sBZR1i9MrqM5pw3o5x9sc57SYiuCQJMKwD8l8g4S7WEHyfGs43EYmiO0/1LE2QJ7765x3tyN4LrH+PIGvrVdFkdeVv23uQ1Vk9kZ9OiCo5+ZvpGIavWFGQ7Cq+QJAu3omKLzHQUpfph8UgRlEGjJo0g07Dc/4vsNE8qF9LRTpThxlMZIvWU4ZPsd/bW4VBipvAMDyMvUBwA1gW/3ehPY4rekuykK7RGcsX9hCoLn0Nm3J9/tHfYk0vS76yNcaYq1saITBlBzqPnrwAc73sQjpMkwfWgdrPl0JsQJ9lRlzeoecyOcmkEQIDAQAB"
+        }
     },
     {
         "uuid": "CB3A9B4A-C9F3-40FA-A6B8-5219ED5FA9ED",
@@ -364,7 +488,11 @@
         "support_url": "https://github.com/olegwukr/polish-privacy-filters/issues",
         "component_id": "ndgeclhidhlfgmjdcapejaldbahmkgbi",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvZaLRYXrVyL6jjJF8guXpjmUFv3nJd8hfLmbldBIiJ21bMPpaypGBjQANxIU1Sfz1jpy9J+OkB1ifoDg0ScWqDCD0zpjjS87g9ANGantkh55Y+TYDe7yGq6JF2ELr618y3UJTSyfMUi2jLlmved/1Zmtuup2+nWS3Od6NfnXmV+pHJXJLTX7n397RVb1RNN8U5WIvx6vnpZPVB2H8YoNJd9JMj2olIm6yt4Y0ODMOOAXuROz02QLBwnlZC39Z+BuNVxW2fqhLqFw28MD308v2uYiY/Vc0enna8UISSvebYwJedwZFCzk1CVWaO0Y6vHOBVtH4DwHb5sVxUzx/KI3dwIDAQAB",
-        "desc": "Defuses anti-adblock from Polish websites"
+        "desc": "Defuses anti-adblock from Polish websites",
+        "list_text_component": {
+            "component_id": "bdnfonbomiianhopbpfgfeekmlcbegfo",
+            "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA77Cpl7pDmqWRY8sjZhvJ+GxIHDmA7PvUZinQz0PoOz3wEuWmuFU6mOOx6uUi83onGMamcu5ofHWAZBNYRIXbbPcpC4a87YLbpfTegKi7TX9BTFrUMUZCKlO74z6LZO8R1APLAcse6rubCkpyyuvMZ4mcbCA+vKv8RPh4YLhSRWhIi/UvueiaTOew4QkAq2W2q1FtStK9w5uBtBJBFX8LR456AMKZ554bpZ9jea9/8kasXvrbujwyx6G1KueQW1QIUlXbVVxGs+fKMMj3UYxIODYQUqXkV1YvWmdZ3jNApnnOyeJJNEAfNlMw/KMJM2m+S9apXqOdR7VhE5SCZ99wlQIDAQAB"
+        }
     },
     {
         "uuid": "AD3E8454-F376-11E8-8EB2-F2801F1B9FD1",
@@ -375,7 +503,11 @@
         "support_url": "https://github.com/tcptomato/ROad-Block",
         "component_id": "hojdjlebfkngledgkgecohjkjjojaekd",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnhLXi2u795hnBUJi/vS8qtMGoTYk9NRefWk+SI6fkqVdiKs/eM6Y8v3To4HgNmtYb4jAoYctcq3/CS3hzGCLEwQbDuL8Y8UP5B6PWgzuiRrAobRl1DtXO1+Q57VIrYTpJVLCqaTulclys7Fka/wD5o78Y0vAfSenBZTzRUXwTZd9Z7SRNwcJyccbi7zL8UDWnJMBnD/dnV7t2q41MHiCgdzimOSuoRZmTBrupVc0QYhqoxy6ePkHFDGL2U25omAZckkzpQbtvJEE2lmg7YqnaSvGDzsmqd+j7hVWjpm/ncArLOWBCbER3MdHwFeOI2rFJWcO7GY5etQsA5128FAv0wIDAQAB",
-        "desc": "Removes advertisements from Romanian websites"
+        "desc": "Removes advertisements from Romanian websites",
+        "list_text_component": {
+            "component_id": "cgmhmpbimmakidhlkcnnehhicoclofep",
+            "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsPK8KQaEM2wDchLR8GfV40qmWdwi2QPpKhBq62Tihw7gmFjKNIQN26fHB+NDn8H/GC5XCmZD2uAMrRvcfR043imLWnCmBU5cHtPoQNAN/VWeffzOMaNn5JIMlpwtFZDfISXAaDiNMPLY1uEEVuVwqoX4bA/U6VfCnkIQcQwGJO58AH50Dk0Deq2xgUWmFpJgCMwGcp0Hv1OEERcVhtmpoaetVtfkUmBsOd0CwcSdT4p9zMXWRuHGmgbMayBXL63hksmnNUBYcyzUqxSDwA4OqaLaNZovLc3CMgVXQ55n3wpo+HmMDhr4OLWULgXsZDne5wehZS6QOaR0G+bqOmev7QIDAQAB"
+        }
     },
     {
         "uuid": "80470EEC-970F-4F2C-BF6B-4810520C72E6",
@@ -386,7 +518,11 @@
         "support_url": "https://forums.lanik.us/viewforum.php?f=102",
         "component_id": "enkheaiicpeffbfgjiklngbpkilnbkoi",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArVVgKRE868yup0HfX4+HyZmJVIk33AKivwvRRfjHRxeC+lLnRjNiY0LKS/K65J6SNLgUsZGfT5u4h4F423O/pbZl6zdfs5kOyStlmLPXhFtF/bIXIsUtdJ0R3dEz+nSg0C2L/FnE5Qr8M4thdmq/DIP1C70mj8pCnX1939hXyR0ymQkYp573O+LJ0q1L41jBqHzNKWngfBc79I2Kbt1pLluBT2X7zZVbb+1ap3Ad/VMeFDB2yurRs88cYJZOal7mgTgI/Zkuzsh2Dnql5+UNOCHinYjcOvUifGgkdsJIJxL57PxRzbriLCNjShoOV3Fpc0XYL1KSWvIVuW0bYeLmrwIDAQAB",
-        "desc": "Removes advertisements from Russian websites"
+        "desc": "Removes advertisements from Russian websites",
+        "list_text_component": {
+            "component_id": "phmomndefejccjmpiehbogokakkmnmgb",
+            "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtUdVZS1RGK6o+gfhEu1d8o061nYg/QCvHhojbyt09I3H+sc3lIr1cpK37msXq+DaFQ1LHbNk+9wTDfe7IIpvMFGSWx27P0T0mh63qjuFzfP5dSIDWhlCgPl8bUbHkf3e1bbNC1TAlGQDjZdxz7t/qDfslICWXLcKVz/1BtT/kG1PPrXjRq+NKBEqqV841RAIXnH4/LcfNLVCTs6EFvqRva4aN1DHuZdejLAMAbgR6JH0cMJ9RBO/5/ebZUL6C0XFjobgdj/2Rh+GYSrxL3jDql7jheKOrTbpJx81z3iUNwghrlHD56BbFs0eC3ZOAYHbIdYBkFIUPwpL78v5xyA94QIDAQAB"
+        }
     },
     {
         "uuid": "1088D292-2369-4D40-9BDF-C7DC03C05966",
@@ -397,7 +533,11 @@
         "support_url": "https://forum.adguard.com/forumdisplay.php?69-%D0%A4%D0%B8%D0%BB%D1%8C%D1%82%D1%80%D1%8B-Adguard",
         "component_id": "dmoefgliihlcfplldbllllbofegmojne",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4p+4n2wNFQCqQBBJDsvs+oqNYGzX3cbpY7fKbCjrRVE5esJK5HZJDoUUg43pPvKrCOIQ+lF+dXpBaCNnO4O/7JeFt2IFRJnKhE3ipIBAAbFymfo5T2uWFdyh6HcK0FNyJ/7FyHnANe7vYhXJS1Fqmh6jTYkAEIbrbmxtzrDMefx3XJcVhUV3XAPlP+K3MerxudIH++4fn3X0vKob5oQQQ9ZZ1PVcW6ZdZTQwQWtaVDb6prT+ULaphRRmnZpZuRXyHMv9KC8YP3K5ou+/Yd3uxxMwKmJXD67ZoNMtS/Dtr0btQsLxiEgox5Swd4iqyLM/SMxr3LqgUIlNwn7KRbMnZwIDAQAB",
-        "desc": "Removes additional advertisements from Russian websites, may break some websites"
+        "desc": "Removes additional advertisements from Russian websites, may break some websites",
+        "list_text_component": {
+            "component_id": "jiajbjlakknofnkmlokcbanjbajpbdkl",
+            "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvmC+nOMvt+lDivZj50XLbNPrcye4W7en/zP+CqvSVZ+MLwcH6oOF/YtLqzVMl05JOAutllDiO0Kwme8E/EpJI5Tw/JIYTLSzm2t3hDbWMo7EB8WobkIp9vXIKjEsRaw/QQR0b6BoqclyunfCutQfM+dADwJStJypwQkUuZPV0Xgl8M9uPDO4srAcrAs5Afc4wIDRxgGL+yWlp/XE0eUrJk37pZY9invINbTlFUoN1g2C3fWaRZ+kuH7AtlHhucKLTHtQIYD/eh3bmq2+0eLcgC6dP87PhSADTujuUIHMG4QivBz8a9o4lmcvZLztjsf5eQDh8+D4En69/IMrpKM9mQIDAQAB"
+        }
     },
     {
         "uuid": "DABC6490-70E5-46DD-8BE2-358FB9A37C85",
@@ -408,7 +548,11 @@
         "support_url": "https://forums.lanik.us/viewforum.php?f=102",
         "component_id": "fmcofgdkijoanfaodpdfjipdgnjbiolk",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApGBuuxC9pqx2s5hUd3K8zeFUtMFt9X+rSKR3elqWztjIQrbOdXSeezHvhAUdzgc+Wv79ZoRf4i4amYs3Mg3wg783BAqLvlu9r6FsUAbcgVQtt+MT3Z4ZepwvzWU0NjUd1q4O2pNEUsE8SPjmOeb3KHOF5WX7CA1uIHT5xGQsU5Uh3VTZC8FIOGjCskDAAnJGUeOowlMBGL2UvlNQLiqzPSvI9byjwxIMN5OfCmxXXr4R9m88oVK2D1gj7vfwBVJcRdV8ner4ZSuT68ncSyaQRtgI3/QyHc0J6giCRFmF0bHN/5kjFIWrHg5+uiBQN4Qt39TVCUU024Fi2RGInvTTdQIDAQAB",
-        "desc": "Removes additional advertisements from Russian websites, may break some websites"
+        "desc": "Removes additional advertisements from Russian websites, may break some websites",
+        "list_text_component": {
+            "component_id": "iiglahilpgmhlcogkkihklnbcjjgpddl",
+            "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAypc9kkULwkl0+NmhXX7MZNsoF/G3QaMJ/sYa468w7rhQzJ8PMkfeGeYtMQnvpLh3pALw4Y0gAlTwWaK21BZWdrsAyjk4IM+gTsztSrK7ffflw4usQSlOI0MJpJ1lj9pKCSeux0Pr0P+mGFWMDIxDyefBbUkMzM1JmsVXsDHVpoHikepAKkBKwW0F8Uzv0jFa1M5BxRK5n9nLOxTA3gCmcxUjeLMAYtQvzGf5pg/YwHz64J+snbwEJo8Lo9dUcpLk9ZoNuMqgoVa7UV4FgXCYhT3c3/cyK6673gy33WW5I+0tu9qTpY263StQ1hUWx2LnylJ4qbI8kKqotiGJy2JoLwIDAQAB"
+        }
     },
     {
         "uuid": "AE657374-1851-4DC4-892B-9212B13B15A7",
@@ -419,7 +563,11 @@
         "support_url": "https://forums.lanik.us/viewforum.php?f=103",
         "component_id": "pdecoifadfkklajdlmndjpkhabpklldh",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2eGyWcTM6Cpmkw6CBBxQbJCgp3Q4jyh+JR/Aqq5G+OFzxFpwlqW0dH9kNuUs30iSt1tt1gMZGYnhPKiGhtX3nV1iYg2K8k82wNqA5+ODfHxnnVn536UoC7rmjXL+mhpymxgkjGCQ+1HVmnCcSC9mxTPy65ihor+YZcRRPo0IhjQTx3NgdpzkGYvpQVjwnw3a5FpRBCbbp3X2x3EGV3DcjvT6DvvxSU/mAUPlXISo9OFHYUpADilqAevXQIs49LSmefSDu4pezGyR/JoRLh7QR4N3fC17V2E0GazWxvn2U985hPE3tvFcH+LM3EypVRCl6E9AiUZCeumqMBffyXw1AwIDAQAB",
-        "desc": "Removes advertisements from Spanish websites"
+        "desc": "Removes advertisements from Spanish websites",
+        "list_text_component": {
+            "component_id": "fejmaeodjeekfldnbegjagemjgnmhfof",
+            "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAv7yIqlQQ/fK5DkO90mULt6tdYXm4sdROKgLMd9PGxuXkTMWt2gI2VgnOIMKXenr6yQ35kx859rr7dcV8bOUPPCVZsu3zU3mxJoPt6+wOZH00na1n6XVS/jHFULOeqKA7fj/2GYyTvdaSpLL2B7u/limqbZ/IQSBoc0GdEfsjEghKFvFhWmZw6g0UAp0ZiJzm13t+ta2FjCDTfrnXJFt1VY/hd4Ip2i4KmBKByR0gfv4ksqY0rSVJhXjcbrXHqBZvRUr/vw6bBmnFVCJlQKS44S/5QLDsmxm2E2kIp2LmSMLjoYPqTZnthCX9/svwCp08LRwvDHtVSS3c5MsgRzwMkwIDAQAB"
+        }
     },
     {
         "uuid": "1FEAF960-F377-11E8-8EB2-F2801F1B9FD1",
@@ -430,7 +578,11 @@
         "support_url": "https://github.com/AdguardTeam/AdguardFilters#adguard-filters",
         "component_id": "jpolmkeojnkicccihhepfbkhcbicimpa",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAs1E/bf3s1EQeJY10IT5/ZMCzfMAm6SKyWUCeHBkWZLcfwyYLJww84EC2jCLeYgwukOmZjwtnDrasVhUyKOif7dKIBEZizsvSldi8tzHqTbX3PFKsLhRXCETbU0kkOlArGRGLaBIhgT07qPtlehYCZoDdowk42025fVtfVEMtZg8yBIqtFT/bDL96lRDQIW+1uAM3uFkzvRtQgsYhoI6JlyqFw6fqowRx8a+zHvtQzAUyIaTGf0OFEHwGCFlHXmTYpcOXlcUAXn4RnJvx+thpeDBtAvT6LubTLNQClBbwjGL5d7NlGNPByYdcZZcvGPmBWX/vnobY5QGP4lWxZvWfFwIDAQAB",
-        "desc": "Removes advertisements from Spanish and Portuguese websites"
+        "desc": "Removes advertisements from Spanish and Portuguese websites",
+        "list_text_component": {
+            "component_id": "meimhmgfbckapkbbbdaoefgnbppmkodp",
+            "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvZOGZijGxkLbvTxJY/4nih6wdCBI7zJLrUwOUMXsv9DOVRJvh8s5CHYRQDwxUhNbWGOubxyjYT8Je2sb/5fLFJXqBFbC+xZQbRAshfpOJjO+ZJC6EAUz+MsG/xWqQZfHHuJ71yLSaSt55dFSvZiF7XqIPIrT3enTdILCgT6Ql42faE6d3EBcQm/lR1fyuBS8PGfcjiIL6rIvcNiTSvU2530m/x8ie2rWijMxJp+JlHejMzc3OJ3Z7Lz+52u/WFWMeTbVNDK4LQ1OEwTPxsARd13UTkk9S0Kf4B6G3OdND3lpzso3CPF3z52i22SUqOJE4nudWKWqkXVoDVNJGebnCwIDAQAB"
+        }
     },
     {
         "uuid": "418D293D-72A8-4A28-8718-A1EE40A45AAF",
@@ -441,7 +593,11 @@
         "support_url": "https://github.com/betterwebleon/slovenian-list",
         "component_id": "lddghfaofadfpaajgncgkbjhalgohfkd",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4cRSF2Rg5SSG6mwE6NQCnX4a0MfzC9URqNFnI4Wf3d3a7CkhmVeNZHxSCGGLxNV9SjCi5tko7NdMqIwnN/vliZV+jnEDi8Lj+zz9nftkaGXe3jNoP7tr/+Qkqphc76j3wIpsQx/vBnfVTn5lrNynZL6qpFzX5dj4ukdJ6BOx1YTNdJV9LOyMWbC5rno1mpd14aS7R2T6xfnm3+nupaZMAbUeN/1bwxDdND/mbjFzFvkPCC+4m758tI/5kSJOefy8kNvp9BM64LXPA4sF59ttJtCIOJDAyhM1P0Danyze2g/0GGnojDuzZilfeSCeEpDsc+S78Tyqz/lMtxt2LZkvoQIDAQAB",
-        "desc": "Removes advertisements from Slovenian websites"
+        "desc": "Removes advertisements from Slovenian websites",
+        "list_text_component": {
+            "component_id": "nnpbcdahaefknppiijdmnckpdgojejck",
+            "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArD9/YNDpxamPQ937PVUqokLSeHB7pZCsRR46lEwLgD9FEQfNFd8Ji0K3irclaF6B0/3H8dvJbp3hjCOfGONWKmM7GpihipzBYEtdd1ueXDhnSoxNV/T87/x+RzaiTM2oznaAp+7jw+TfMkDyKYh3cFQMROTxTcE3rs4Ocs/mhBsFbumU42GRpQUSLB9f4L4KhLo6SGby2FYSSHspo46m6xJ63sGnQPLyiuH4hOF00b/XEQUUH6MYCg2WL51LZuVgFkcHWSBK/8HihZOn2ndAr2e2MEtqH7tmQMwQmVqouX4WITlbJ0XnrNUs0o8IYbOUmtp0SWTJtPHpYDeot5DXAwIDAQAB"
+        }
     },
     {
         "uuid": "7DC2AC80-5BBC-49B8-B473-A31A1145CAC1",
@@ -452,7 +608,11 @@
         "support_url": "https://github.com/lassekongo83/Frellwits-filter-lists",
         "component_id": "oimfmeehpinnecjghphifehbbnddjkmf",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA17Vf1qj8dWwYVtGpBHWc9gLiITU1XrTnb1sDASIeuKYp9JNBtEnBwy4oBlOoZd2uWFKxXrRtaimdwqa627gi9DB17t/RgzisXSpLubXbVVelRWllaX26SioGxsGcQhS2/e1Bc0inQ8GODM6mk5FPZ9RObFN1N/QVz35anN4VNcjtETD/XpujYXE1BU3C0KGBlWwc+cQZ6sGojWEPrb7aRXSTJ5y/ugwGomTTpbT+Jt9nFrMfuAmJHvWS0Ev96dDmn1zsuoPGUExVFjGBunphRYMVCg9LUGzY0FN5+dp6fljrTJrtUOEfvh40vmjahKd0w6bKpgTAOUEaWulmVSr37QIDAQAB",
-        "desc": "Removes advertisements from Swedish websites"
+        "desc": "Removes advertisements from Swedish websites",
+        "list_text_component": {
+            "component_id": "ggjlfgjhaeedkajcdpomeidjlniafdnp",
+            "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtMkbz7fkdzW7Gh+/F9yhFSSNRpWYe1FRYEkVPxClGGL7yta9cwmskmDqskAHaIP5JRQuvgJ71cSUgBWtUmDyhB4Cl5ZE6VSpe88xJxcrOctpwewwqbpwZB2/8PMkQFPXkjLoc1VvYXHRdjXVZumQq0wq3xnWNcp+o7WHebgciZIEBaXWyvg7Ire156qx0ru4AnxAkccKrv/iHCaKy7dcaEj7Npw85/s0zhLIK4jfwdYRe3/U1Tpilgq6R6JQ1rsN0eCi7aGuam9p7v5JZH8823NZ97jkURAJDJTfvY7U8auca1pSiBSzPBIrfkNXN6D0lRcLdO6Bm6cs52JbxYo4MwIDAQAB"
+        }
     },
     {
         "uuid": "658F092A-F377-11E8-8EB2-F2801F1B9FD1",
@@ -463,7 +623,11 @@
         "support_url": "https://github.com/easylist-thailand/easylist-thailand",
         "component_id": "jplgiejfnpolnfnigblbfeeidoimingd",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAy4EQ0IdWDAAqRT6ymtxWG32Whfmv5TMxKuEP3rs9LMfa+iU+xiyE/XvWjgA58n4Bs2vQgefCoqY+a9B0TUkqz0nDcrBi371w1EZSxNRySslO5VvLHdRdYwynTMwDsAlHIPZ6pgh9zwprW1Lxz31CC2EHJeBGmBQ/S8My/VRiN8Y2Jj7yZDX1rTvBrYPj5XAwe2MAPAsMJD4lHcx7uClEbVq/4AxNpmNay5kamFaX6qt8/765RyPYuqgneharP7EJ9HToH56l/KR7doOywTyVPQYvEhD+a1mioMfEtYNxvqY4lKDhctTV8aU7RItAgwGTW+msldvdPfs3QWV5o7yrtQIDAQAB",
-        "desc": "Removes advertisements from Thai websites"
+        "desc": "Removes advertisements from Thai websites",
+        "list_text_component": {
+            "component_id": "johkmlmpfakcaopiapbmcocgpkabdmed",
+            "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA5ndE+g/8K+nvdkIEct4mtVFQpexmeklQqtbBstIw2hI5aF+HAvgtMk5RTn0qicwGku1kCJEn0TDP8IbAMhgcODc3BzCmPwnE/oHJ9EvO56+doo8SL5SJaQ1ws2Os1lOZeatnKWr07SaCL39M/Ychvj3yccDVer7T339XmZ/TvkaKMlrKoFYGJzoGPjoBS7vw2SvsFWHCgsVEtpbGEXZD029z1YaNDGPBPvnuk30Ir9sPw4uurqTZxR9RKquJB/QBm3l/eT3UICED30yFthpP+8DVLpH6J5lKM9EqD8df4VyiSjotYAqNNJKgTNWOzQeFud/t26sQgyXGVUBBT2VNEwIDAQAB"
+        }
     },
     {
         "uuid": "1BE19EFD-9191-4560-878E-30ECA72B5B3C",
@@ -474,7 +638,11 @@
         "support_url": "https://forum.adguard.com/forumdisplay.php?51-Filter-Rules",
         "component_id": "oooemoeokehlgldpjjhcgbndjcekllim",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2We4hmp3TwsrKyOb6rF/mCjy9TW3w9n9CD1rZMXUF3U6CCgxH4lps5HiLlxUFaIhhcUEXrGlXbk4TE2LlTv4VS53O23YixZXQ/xMmpWSyBvc3/jBCrAAcvDLAZY53J1T/9t7DNZdpXkX3rNpYB4L5/5dyzQI+sZZoTBe5dLyJOR1uDZJphpXRWSKqBRLn4SJ5uOGgtqG5J4rMhB+SUrNhWs8AyM8+tdoaxOjx7n+PA2Rx7/foty1Bbd7Hfc1Eg0C9R40inJNgH+IDxZ07ZFqiAuY1Z16lr4bwunk7ft4tTafci0M2t86JkoH0B4yiTBKthB6AkmZ0/dejeQeOBszYQIDAQAB",
-        "desc": "Removes advertisements from Turkish websites"
+        "desc": "Removes advertisements from Turkish websites",
+        "list_text_component": {
+            "component_id": "gomenlogbembmkbghmaoledggliepdef",
+            "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2l4J/f1wAJESK4G74P/2aZMsK+r8oUGB2QIN3Ny5tFxONihjidt9wgmjXQvsR5AYhLamylmH3u9u8mo6NC4b0qVE6imybPgp9/Z826O4VOCBd3yVxe6TCf76tuLSRfUjzreqt3Q6ly0JxgaoKXTWOnu3aoQyg/MnBmZ+REpKcE6W0Pyts1/yGDWs4S37tS2uCEmd2Wi4pUWfmzDE/RtTbhNNxoLoa6GczoeSXZww5emW2LahpE6Y8wGz/mPwjbUn0//T2y4Uqn1/HfMANEF8/t8ykk7cWXB3HdA8abg2Vib+dweCIiV2ZDFcx0l0j/SGCIDKwQYWZZkfF3P7Hp/RwwIDAQAB"
+        }
     },
     {
         "uuid": "6A0209AC-9869-4FD6-A9DF-039B4200D52C",
@@ -485,7 +653,11 @@
         "support_url": "https://abpvn.com/",
         "component_id": "cklgijeopkpaadeipkhdaodemoenlene",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAymFhKEG/UJ8ZyKjdx4xfRFtECXdWXixG8GoS3mrw/haeVQoB1jXmPBQTZfL2WGZqYvrAkHRRel7XEoZNYziP3bCYbS4yVqKnDUp1u5GIsMsN0Pff1O1SHEbqClb79vAVhftNq1VQkHPpXQdoSiINQ12Om8WbOIuaNxkrTToFW7XRMtbI3tluoLUSy9YTkCEGah68Dl1uL6nOzOxaMV1iQRRk5Pw4ugTzwGHHL2U2kDYDNrlywK8cUIFgtZskqQ/TF1zF6u9xTGjwjB9X319XrTg2llcojCgj/dllBuXL2aJoDsS3qAVzqbSYxIE6bQU8JX8wv+KCDMpJt/dHPQqOMwIDAQAB",
-        "desc": "Removes advertisements from Vietnamese websites"
+        "desc": "Removes advertisements from Vietnamese websites",
+        "list_text_component": {
+            "component_id": "ooamlicohiiaodkaemgoimcihidbedmp",
+            "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3NaOxndIgpo142VxPI2iWEKwvfFbKsQpxZeGzLGbhO7SwFi7AcEBvDOS6Ufc2PQ3Cz7+TxvUO8a4uEVK/SEiNtMhfL7LGlfMyxV17hIJEjWN1ytEEAALjXJFyVkcz0pAhPC0RY/ti378dSLYL9HetA4XfeO0aC7l23dirQMZMRPfSFvzaZtrp2t35PbQCuMqDW9jbPtdwSSswa7wVYFdafaT48WDuMxxKrggWikMBDxE9/Jihd7179Bd0pmlVreBsWhj+LjLUkf+j4UksUiyttKgQ3+5ZyV5k/tzmhN2HaJC9/q+hvboBz1giOcpSb7u4PbmA82o1K62nKS5c77nTwIDAQAB"
+        }
     },
     {
         "uuid": "319A754E-065A-465F-B09D-3F2C7BF1E67B",
@@ -496,6 +668,10 @@
         "support_url": "https://github.com/uBlockOrigin/uAssets",
         "component_id": "bfoofkaohomljmodljoameijbaichadj",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAx6oamYGdGGq5ZITZdjTfIYUdkUFDfer3SBG2Dp/PLpCktna778IR28lrwrA9mlQQDCwmWezRNaX9n/hIEemPwq8Fijp3v2rlXwj2xoskwxNPuHB9qETUZh1K2owZkLngrLR8UJP0kOcpCGCxiQ9Pn8kBoeNsDOx1yHnVmU89UUqGYNwIeSUDcrOdi8f3CZUgtOxMNy5+3s1lrmgWnt8gEpQptBS7G4Ptn7sYtX9HfMW+c8AEluoxtRyB2hcGMb9wZ8fUbYbvLtu5agSJlXi67hSHa5tSAQCCZO4Fd4Xvv5TX3AIaz0dFwJNbGp9HLzm974TfaqFkVWFZ5FdlRvD71QIDAQAB",
-        "desc": "Removes Web Annoyances, Supplemental uBO list"
+        "desc": "Removes Web Annoyances, Supplemental uBO list",
+        "list_text_component": {
+            "component_id": "pnoagbonokhdnppohfeemefhjbbofplk",
+            "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0BMvGe5WudkwwjswOQ61mbs6L/NNWKQK3kyw10Ew2oRWR5Jggr9IRFc3nT7tIvYZ0l/6tbOzoqM07Z3AW7ASK+am8TL3gw4nxZuduCdEJreJdlTKHxa7/Q0eYyNrTzVyu2zsiSZUFMtrWEhPdptnE15pA4NW7cy2rOWkTyG+nLZzDP1JEov3ZHia42B9RorQLN60dLLhYZl0E073FCra3Tv3wyNwnzvVskcPC9ljRSxH34UYCkjvZH8yHSZE9e/Oda2Tza3HxTy2Dm3Iu1PpfjJBYJCd76ZChlf0Pwb4hvE4YjmZd2EGXNnSpVjUrKDpSSaBORbURkm8tRXFRCs66QIDAQAB"
+        }
     }
 ]

--- a/generate_component.sh
+++ b/generate_component.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/sh
+
+# See the README for more information about this script.
+
+TEMPFILE="$(mktemp)"
+
+openssl genrsa 2048 2>/dev/null | openssl pkcs8 -topk8 -nocrypt -out $TEMPFILE
+PUBKEY=$(openssl rsa -in $TEMPFILE -pubout -outform DER 2>/dev/null | openssl base64 -A)
+COMPONENTID=$(openssl rsa -in $TEMPFILE -pubout -outform DER 2>/dev/null | shasum -a 256 | head -c32 | tr 0-9a-f a-p)
+
+PEMFILE="ad-block-updater-$COMPONENTID.pem"
+
+echo "$PUBKEY"
+echo
+echo "$COMPONENTID"
+echo
+
+mv "$TEMPFILE" "$PEMFILE"
+
+echo "Private key written to $PEMFILE."
+echo "Please upload it to 1Password and make sure it is synced with Jenkins."


### PR DESCRIPTION
Added:
- a new script to generate a private key pem file, a base64 public key, and a component ID for future list components
- supporting documentation for the new script
- a gitignore entry to make sure that those pem files don't get accidentally checked in to git
- plaintext component info for all other regional lists, following the successful cookie list plaintext rollout from https://github.com/brave/adblock-resources/pull/81

All new component PEMs are uploaded to 1Password and Jenkins.