### PR TITLE
Add cbs snippets to counter video ads

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -32,6 +32,22 @@
         "resourcePath": "de-amp.js"
     },
     {
+        "name": "cbs",
+        "aliases": [],
+        "kind": {
+            "mime": "application/javascript"
+        },
+        "resourcePath": "cbs.js"
+    },
+    {
+        "name": "cbs0",
+        "aliases": [],
+        "kind": {
+            "mime": "application/javascript"
+        },
+        "resourcePath": "cbs0.js"
+    },
+    {
         "name": "touch-fix",
         "aliases": [],
         "kind": {

--- a/resources/cbs.js
+++ b/resources/cbs.js
@@ -1,0 +1,20 @@
+/// cbs.js
+(() => {
+    window.XMLHttpRequest.prototype.open = new Proxy(window.XMLHttpRequest.prototype.open, {
+        apply: async (a, b, c) => {
+            const d = c[1];
+            return "string" != typeof d || 0 === d.length ? Reflect.apply(a, b, c) : (d.match(/pubads\.g\.doubleclick.net\/ondemand\/hls\/.*\.m3u8/) && b.addEventListener("readystatechange", function() {
+                if (4 === b.readyState) {
+                    const a = b.response;
+                    Object.defineProperty(b, "response", {
+                        writable: !0
+                    }), Object.defineProperty(b, "responseText", {
+                        writable: !0
+                    });
+                    const c = a.replaceAll(/#EXTINF:(\d|\d\.\d+)\,\nhttps:\/\/redirector\.googlevideo\.com\/videoplayback\?[\s\S]*?&source=dclk_video_ads&[\s\S]*?\n/g, "");
+                    b.response = c, b.responseText = c
+                }
+            }), Reflect.apply(a, b, c))
+        }
+    })
+})();

--- a/resources/cbs0.js
+++ b/resources/cbs0.js
@@ -1,0 +1,16 @@
+/// cbs0.js
+(() => {
+    const a = window.fetch;
+    window.fetch = new Proxy(window.fetch, {
+        apply: async (b, c, d) => {
+            const e = d[0];
+            if ("string" != typeof e || 0 === e.length) return Reflect.apply(b, c, d);
+            if (e.match(/pubads\.g\.doubleclick\.net\/ondemand\/.*\/content\/.*\/vid\/.*\/streams\/.*\/manifest\.mpd|pubads\.g\.doubleclick.net\/ondemand\/hls\/.*\.m3u8/)) {
+                const b = await a(...d);
+                let c = await b.text();
+                return c = c.replaceAll(/<Period id="(pre|mid|post)-roll-.-ad-[\s\S]*?>[\s\S]*?<\/Period>|#EXTINF:(\d|\d\.\d+)\,\nhttps:\/\/redirector\.googlevideo\.com\/videoplayback\?[\s\S]*?&source=dclk_video_ads&[\s\S]*?\n/g, ""), new Response(c)
+            }
+            return Reflect.apply(b, c, d)
+        }
+    })
+})();


### PR DESCRIPTION
Given the popularity, we should block these ads. Changes in paramount/cbs. Ads are currently being shown: Based on the new snippet; thanks to Adguard `https://raw.githubusercontent.com/mapx-/test/master/us.js` https://github.com/AdguardTeam/AdguardFilters/issues/129658

https://github.com/uBlockOrigin/uAssets/issues/14849#issuecomment-1248962943

Still needed:
```
cbs.com,paramountplus.com##+js(cbs)
cbs.com,paramountplus.com##+js(cbs0)
```
And others:
https://github.com/AdguardTeam/AdguardFilters/commit/c2fc8a1b6f7ee237ec664333d4436e1719da99f8