### PR TITLE
Add nbc.js metdata

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -48,6 +48,14 @@
         "resourcePath": "cbs0.js"
     },
     {
+        "name": "nbc",
+        "aliases": [],
+        "kind": {
+            "mime": "application/javascript"
+        },
+        "resourcePath": "nbc.js"
+    },
+    {
         "name": "touch-fix",
         "aliases": [],
         "kind": {


### PR DESCRIPTION
Missed the metadata addition.  Adds from https://github.com/brave/adblock-resources/pull/85