### PR TITLE
Update urlhaus list to use the online (light) version

### DIFF
--- a/filter_lists/default.json
+++ b/filter_lists/default.json
@@ -60,7 +60,7 @@
         "support_url": "https://easylist.to/"
     },
     {
-        "url": "https://malware-filter.gitlab.io/malware-filter/urlhaus-filter-agh.txt",
+        "url": "https://malware-filter.gitlab.io/malware-filter/urlhaus-filter-ag-online.txt",
         "title": "URLhaus Malicious URL Blocklist",
         "format": "Standard",
         "support_url": "https://gitlab.com/malware-filter/urlhaus-filter"


### PR DESCRIPTION
Reduces rule count from ~45k to ~6k, which should significantly improve memory usage in the browser and bandwidth when shipping lists to users