### PR TITLE
Use `agh` instead of `ag` version for urhaus

### DIFF
--- a/filter_lists/default.json
+++ b/filter_lists/default.json
@@ -60,7 +60,7 @@
         "support_url": "https://easylist.to/"
     },
     {
-        "url": "https://malware-filter.gitlab.io/malware-filter/urlhaus-filter-ag-online.txt",
+        "url": "https://malware-filter.gitlab.io/malware-filter/urlhaus-filter-agh-online.txt",
         "title": "URLhaus Malicious URL Blocklist",
         "format": "Standard",
         "support_url": "https://gitlab.com/malware-filter/urlhaus-filter"


### PR DESCRIPTION
https://github.com/brave/adblock-resources/pull/89#issuecomment-1320386616

`adblock-rust` currently doesn't support `$all` for some reason, but this will fix it

(thanks @TheVampireInLoveWithTheCorpsesBlood)