### PR TITLE
Unify regional and default list formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,21 +43,41 @@ The `filter_lists/*.json` files are lists of elements, each describing a filter 
 
 ```json
 {
-    "url": "https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/new-list.txt",
     "title": "New Filter Rules",
-    "format": "Standard",
-    "include_redirect_urls": false,
-    "support_url": "https://github.com/brave/adblock-lists"
+    "desc": "Removes new elements"
+    "langs": [],
+    "component_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAs...IDAQAB",
+    "list_text_component": {
+        "component_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAs...IDAQAB",
+    },
+    "sources": [
+        {
+            "url": "https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/new-list.txt",
+            "title": "Brave New List",
+            "format": "Standard",
+            "support_url": "https://github.com/brave/adblock-lists",
+        }
+    ]
 }
 ```
 
-- `url` is the URL where the filter list is actually located and can be downloaded from. Filter list should be a list of rules in the format specified in `format` in a `.txt` file.
+- `uuid` is currently only used by iOS, along with versions of the Desktop/Android browser prior to [brave/brave-core#15077](https://github.com/brave/brave-core/pull/15077). It's a UUID generated with, for example, the CLI tool `uuidgen`.
 
-- `title` is a human-readable title for the filter list.
+- `title` is a human-readable title for the filter list component. Each source also has a title, which is a human-readable title for each individual list making up the full component.
+
+- `desc` is a short human-readable description of what the filter list is designed to block.
+
+- `langs` is a list of _locale codes_ for the given component, allowing it to be preselected in-browser by users in the corresponding regions. Note that despite the name, it should not list _language codes_.
+
+- `component_id` and `base64_public_key` are unique constants generated per-list such that the lists can be served in CRX components created by [brave-core-crx-packager](https://github.com/brave/brave-core-crx-packager). Note that the ones inside `list_text_component` should not have the same values.
+
+- `sources` is a list of individual filter lists that are concatenated together in order to create the full list for a component.
+
+- `url` is the URL where a filter list source can be downloaded from. It should be a list of rules in the format specified in `format` in a plaintext file.
 
 - `format` is either ABP/uBO-style format ("Standard", most common) or IP address and hostname ("Hosts").
-
-- `include_redirect_urls` permits parsing of `redirect-url` filter option. This has security implications. This field is optional and defaults to `false`. 
 
 - `support_url` is somewhere a user can ask for help with the filter list.
 
@@ -65,11 +85,13 @@ The `filter_lists/*.json` files are lists of elements, each describing a filter 
 
 The `generate_component.sh` script can be used to help create a new filter list component.
 It will generate:
-- A public key (corresponding to the `base64_public_key` field)
-- A component ID (corresponding to the `component_id` field)
+- A public key (corresponding to the `list_text_component.base64_public_key` field)
+- A component ID (corresponding to the `list_text_component.component_id` field)
 - The component's private key (in a new PEM file)
 
 The script should be run with no arguments.
 The resulting PEM file will be named `ad-block-updater-<component_id>.pem`.
 This file should be uploaded as a secret to Brave's `Extension Developers` vault in 1Password.
 Once it is uploaded, devops will also need to sync it the with Jenkins so that it can be used to build the component.
+
+Note that until iOS is updated to use plaintext list components (see [this tracking issue](https://github.com/brave/brave-ios/issues/5974)), each list will also need another separate `component_id` and `base64_public_key`, as well as `uuid`, defined at the top-level of the object.

--- a/filter_lists/default.json
+++ b/filter_lists/default.json
@@ -1,116 +1,130 @@
 [
     {
-        "url": "https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/filters.txt",
-        "title": "uBlock Origin Filters",
-        "format": "Standard",
-        "support_url": "https://github.com/uBlockOrigin/uAssets"
-    },
-    {
-        "url": "https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/filters-2020.txt",
-        "title": "uBlock Origin 2020 Filters",
-        "format": "Standard",
-        "support_url": "https://github.com/uBlockOrigin/uAssets"
-    },
-    {
-        "url": "https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/filters-2021.txt",
-        "title": "uBlock Origin 2021 Filters",
-        "format": "Standard",
-        "support_url": "https://github.com/uBlockOrigin/uAssets"
-    },
-    {
-        "url": "https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/filters-2022.txt",
-        "title": "uBlock Origin 2022 Filters",
-        "format": "Standard",
-        "support_url": "https://github.com/uBlockOrigin/uAssets"
-    },
-    {
-        "url": "https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/filters-2023.txt",
-        "title": "uBlock Origin 2023 Filters",
-        "format": "Standard",
-        "support_url": "https://github.com/uBlockOrigin/uAssets"
-    },
-    {
-        "url": "https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/badware.txt",
-        "title": "uBlock Origin filters - Badware risks",
-        "format": "Standard",
-        "support_url": "https://github.com/uBlockOrigin/uAssets"
-    },
-    {
-        "url": "https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/privacy.txt",
-        "title": "uBlock Origin filters – Privacy",
-        "format": "Standard",
-        "support_url": "https://github.com/uBlockOrigin/uAssets"
-    },
-    {
-        "url": "https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/resource-abuse.txt",
-        "title": "uBlock Origin filters – Resource abuse",
-        "format": "Standard",
-        "support_url": "https://github.com/uBlockOrigin/uAssets"
-    },
-    {
-        "url": "https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/unbreak.txt",
-        "title": "uBlock Origin filters - Unbreak",
-        "format": "Standard",
-        "support_url": "https://github.com/uBlockOrigin/uAssets"
-    },
-    {
-        "url": "https://easylist.to/easylist/easylist.txt",
-        "title": "EasyList",
-        "format": "Standard",
-        "support_url": "https://easylist.to/"
-    },
-    {
-        "url": "https://easylist.to/easylist/easyprivacy.txt",
-        "title": "EasyPrivacy",
-        "format": "Standard",
-        "support_url": "https://easylist.to/"
-    },
-    {
-        "url": "https://malware-filter.gitlab.io/malware-filter/urlhaus-filter-agh-online.txt",
-        "title": "URLhaus Malicious URL Blocklist",
-        "format": "Standard",
-        "support_url": "https://gitlab.com/malware-filter/urlhaus-filter"
-    },
-    {
-        "url": "https://pgl.yoyo.org/adservers/serverlist.php?hostformat=adblockplus&showintro=1&mimetype=plaintext",
-        "title": "Peter Lowe's Ad and tracking server list",
-        "format": "Standard",
-        "support_url": "https://pgl.yoyo.org/adservers/"
-    },
-    {
-        "url": "https://raw.githubusercontent.com/brave/adblock-lists/master/brave-unbreak.txt",
-        "title": "Brave Unbreak",
-        "format": "Standard",
-        "support_url": "https://github.com/brave/adblock-lists"
-    },
-    {
-        "url": "https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/brave-specific.txt",
-        "title": "Brave Specific",
-        "format": "Standard",
-        "support_url": "https://github.com/brave/adblock-lists"
-    },
-    {
-        "url": "https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/brave-social.txt",
-        "title": "Brave Social",
-        "format": "Standard",
-        "support_url": "https://github.com/brave/adblock-lists"
-    },
-    {
-        "url": "https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/brave-unbreak.txt",
-        "title": "Brave Unbreak",
-        "format": "Standard",
-        "support_url": "https://github.com/brave/adblock-lists"
-    },
-    {
-        "url": "https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/brave-android-specific.txt",
-        "title": "Brave Android-Specific Rules",
-        "format": "Standard",
-        "support_url": "https://github.com/brave/adblock-lists"
-    },
-    {
-        "url": "https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/brave-sugarcoat.txt",
-        "title": "SugarCoat Rules",
-        "format": "Standard",
-        "support_url": "https://github.com/brave-experiments/sugarcoat-pipeline"
+        "uuid": "default",
+        "title": "Brave Ad Block Updater",
+        "desc": "Default lists for Brave Browser",
+        "langs": [],
+        "component_id": "cffkpbalmllkdoenhmdmpbkajipdjfam",
+        "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAs0qzJmHSgIiw7IGFCxij1NnB5hJ5ZQ1LKW9htL4EBOaMJvmqaDs/wfq0nw/goBHWsqqkMBynRTu2Hxxirvdbcugn1Goys5QKPgAvKwDHJp9jlnADWm5xQvPQ4GE1mK1/I3ka9cEOCzPW6GI+wGLiVPx9VZrxHHsSBIJRaEB5Tyi5bj0CZ+kcfMnRTsXIBw3C6xJgCVKISQUkd8mawVvGvqOhBOogCdb9qza5eJ1Cgx8RWKucFfaWWxKLOelCiBMT1Hm1znAoVBHG/blhJJOD5HcH/heRrB4MvrE1J76WF3fvZ03aHVcnlLtQeiNNOZ7VbBDXdie8Nomf/QswbBGaVwIDAQAB",
+        "list_text_component": {
+            "component_id": "iodkpdagapdfkphljnddpjlldadblomo",
+            "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsD/B/MGdz0gh7WkcFARnZTBX9KAw2fuGeogijoI+fET38IK0L+P/trCT2NshqhRNmrDpLzV2+Dmes6PvkA+OdQkUV6VbChJG+baTfr3Oo5PdE0WxmP9Xh8XD7p85DQrk0jJilKuElxpK7Yq0JhcTSc3XNHeTwBVqCnHwWZZ+XysYQfjuDQ0MgQpS/s7U04OZ63NIPe/iCQm32stvS/pEya7KdBZXgRBQ59U6M1n1Ikkp3vfECShbBld6VrrmNrl59yKWlEPepJ9oqUc2Wf2Mq+SDNXROG554RnU4BnDJaNETTkDTZ0Pn+rmLmp1qY5Si0yGsfHkrv3FS3vdxVozOPQIDAQAB"
+        },
+        "sources": [
+            {
+                "url": "https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/filters.txt",
+                "title": "uBlock Origin Filters",
+                "format": "Standard",
+                "support_url": "https://github.com/uBlockOrigin/uAssets"
+            },
+            {
+                "url": "https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/filters-2020.txt",
+                "title": "uBlock Origin 2020 Filters",
+                "format": "Standard",
+                "support_url": "https://github.com/uBlockOrigin/uAssets"
+            },
+            {
+                "url": "https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/filters-2021.txt",
+                "title": "uBlock Origin 2021 Filters",
+                "format": "Standard",
+                "support_url": "https://github.com/uBlockOrigin/uAssets"
+            },
+            {
+                "url": "https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/filters-2022.txt",
+                "title": "uBlock Origin 2022 Filters",
+                "format": "Standard",
+                "support_url": "https://github.com/uBlockOrigin/uAssets"
+            },
+            {
+                "url": "https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/filters-2023.txt",
+                "title": "uBlock Origin 2023 Filters",
+                "format": "Standard",
+                "support_url": "https://github.com/uBlockOrigin/uAssets"
+            },
+            {
+                "url": "https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/badware.txt",
+                "title": "uBlock Origin filters - Badware risks",
+                "format": "Standard",
+                "support_url": "https://github.com/uBlockOrigin/uAssets"
+            },
+            {
+                "url": "https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/privacy.txt",
+                "title": "uBlock Origin filters – Privacy",
+                "format": "Standard",
+                "support_url": "https://github.com/uBlockOrigin/uAssets"
+            },
+            {
+                "url": "https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/resource-abuse.txt",
+                "title": "uBlock Origin filters – Resource abuse",
+                "format": "Standard",
+                "support_url": "https://github.com/uBlockOrigin/uAssets"
+            },
+            {
+                "url": "https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/unbreak.txt",
+                "title": "uBlock Origin filters - Unbreak",
+                "format": "Standard",
+                "support_url": "https://github.com/uBlockOrigin/uAssets"
+            },
+            {
+                "url": "https://easylist.to/easylist/easylist.txt",
+                "title": "EasyList",
+                "format": "Standard",
+                "support_url": "https://easylist.to/"
+            },
+            {
+                "url": "https://easylist.to/easylist/easyprivacy.txt",
+                "title": "EasyPrivacy",
+                "format": "Standard",
+                "support_url": "https://easylist.to/"
+            },
+            {
+                "url": "https://malware-filter.gitlab.io/malware-filter/urlhaus-filter-agh-online.txt",
+                "title": "URLhaus Malicious URL Blocklist",
+                "format": "Standard",
+                "support_url": "https://gitlab.com/malware-filter/urlhaus-filter"
+            },
+            {
+                "url": "https://pgl.yoyo.org/adservers/serverlist.php?hostformat=adblockplus&showintro=1&mimetype=plaintext",
+                "title": "Peter Lowe's Ad and tracking server list",
+                "format": "Standard",
+                "support_url": "https://pgl.yoyo.org/adservers/"
+            },
+            {
+                "url": "https://raw.githubusercontent.com/brave/adblock-lists/master/brave-unbreak.txt",
+                "title": "Brave Unbreak",
+                "format": "Standard",
+                "support_url": "https://github.com/brave/adblock-lists"
+            },
+            {
+                "url": "https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/brave-specific.txt",
+                "title": "Brave Specific",
+                "format": "Standard",
+                "support_url": "https://github.com/brave/adblock-lists"
+            },
+            {
+                "url": "https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/brave-social.txt",
+                "title": "Brave Social",
+                "format": "Standard",
+                "support_url": "https://github.com/brave/adblock-lists"
+            },
+            {
+                "url": "https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/brave-unbreak.txt",
+                "title": "Brave Unbreak",
+                "format": "Standard",
+                "support_url": "https://github.com/brave/adblock-lists"
+            },
+            {
+                "url": "https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/brave-android-specific.txt",
+                "title": "Brave Android-Specific Rules",
+                "format": "Standard",
+                "support_url": "https://github.com/brave/adblock-lists"
+            },
+            {
+                "url": "https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/brave-sugarcoat.txt",
+                "title": "SugarCoat Rules",
+                "format": "Standard",
+                "support_url": "https://github.com/brave-experiments/sugarcoat-pipeline"
+            }
+        ]
     }
 ]

--- a/filter_lists/regional.json
+++ b/filter_lists/regional.json
@@ -1,767 +1,767 @@
 [
     {
         "uuid": "9FCEECEC-52B4-4487-8E57-8781E82C91D0",
-        "url": "https://easylist-downloads.adblockplus.org/Liste_AR.txt",
         "title": "Liste AR",
-        "format": "Standard",
+        "desc": "Removes advertisements on Arabic websites",
         "langs": ["ar"],
-        "support_url": "https://forums.lanik.us/viewforum.php?f=98",
         "component_id": "gpgegghiabhggiplapgdfnfcmodkccji",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnbHn298ZQjKnWlC6NgkvS3Dr7Neu87d1h8s3b9GTlc1QNDWiYgY5IfWVq/1FBw2nUFE/v8fNJg8quq8Z2nS8dYiJDVSGRggiCooa0OTCARL0BsGxHZO6s2QROYIcxPVnzISqg5zRIBc+8npE68uVUrDR6q/KdJ8siL2hrR/NybPp+uTK44lHOEIBFm8ih1rC6z+Y5dHfhax0CuL6wlWwVNcFe1macYEcOXShwkUOADh6rEBQZKJmv474xJutmB8nIpGq7C2Hn2HNNyfA6tYmhVlsaeEC44phGITKDai03wFsWWkHQPEU5HwFzKQGIBFwudyO8iigO5m+d3XSzgSZtQIDAQAB",
-        "desc": "Removes advertisements on Arabic websites",
         "list_text_component": {
             "component_id": "mpgdjfnjjmglioiflfioiappfbdbkeno",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAr3arBYpWfbSQIYLDp6nVB4aQG+2r5NOh1n5YuD8zhYa8lN4G6m1/JqcMkbK/KE1ujqG4q9Orh5d0FjumAtdzw/KkEEg14OKmu3+xeHxV2YbIDJGEW7aTMwlqO0Nz0Da+Z41hbMLcjjCHl2KrSoAM4ogUYVtYW1GLplfH3P5ss+hM1qrwBsPI+pXIMyK1ZqTc8552+SxQFJ7RFbn1h1t9cSu0JoNw3SiIGmrOT45ZROeQ3D5tP1MCPqnOsanTeo0NTnt65AuGhj5EvOcSGZnbhhQulwpzA72r1reQ3wBlXjdIR0w1S1wAn75LXYgPcBMaST3Cfais0hs/eihWQceS7QIDAQAB"
-        }
+        },
+        "url": "https://easylist-downloads.adblockplus.org/Liste_AR.txt",
+        "format": "Standard",
+        "support_url": "https://forums.lanik.us/viewforum.php?f=98"
     },
     {
         "uuid": "F61D6B7B-4110-4EA4-9C81-38FB4CE90AEC",
-        "url": "https://raw.githubusercontent.com/blocklistproject/Lists/master/adguard/porn-ags.txt",
         "title": "Blocklists Anti-porn list",
-        "format": "Standard",
+        "desc": "Blocks access to porn websites",
         "langs": [],
-        "support_url": "https://github.com/blocklistproject/Lists",
         "component_id": "llncepohmekfljgcdgnlikjindhabpom",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4vDS5+s0ImGnynie+7tavH69T65aWhZ5VSSaaplycMbt4kYT9RIadrJM8SFyvfybCeluDavGQSxmgX+egFVIbrGeZjl/BvfOWQXZ9qfPdbL0NAAgCSwzsaLag/Mpeg17R2rbMJnEz9zPyT/ZCjXwq5JVtyWx+Bgnxl2T/0zOYAqbVta+nm/dEO0TUQBjEP8YcHItsj/zsOdhXfsPHjIs/hlaJkbUwBw5ziFj01lmBIzwd5LLUlnFmeKDduYibMO/bNnKXZDMTwgBH+rSSErARyLjACkjl0xFBsJJA4gMQ1IFC7vGzUAFxIpU/DJsJymxWaSUcY6Np0Ew+RMNygn9hwIDAQAB",
-        "desc": "Blocks access to porn websites",
         "list_text_component": {
             "component_id": "lbnibkdpkdjnookgfeogjdanfenekmpe",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvLwepAP2UzEBpQraDyQ4rbGWmswgYLEyvEssFGmZ9uAHj3jtP2vE2w4AwpIsyg6zaD2Wx7fsgPTHxb1hZrT7lMK7RJzzrAeINlfbNwzxte7lkedxLdEaq+HrQunnBK9MY1fSonVmMohYCi7Gk+loUrGnQpuspVI6VJJ4N34sb8qiKueyx5+IyQpIBNPclhGs22yxohHN15r9sOcqsZ9XwNR1r7wZHE+pK1gu0a70zoY0WPPXFHZSHlbCz4VxLWeHwWdnx3yVOkgVOiacilCuutcptl+09IVFYHxTjquOZHZHcLFM78nju1K4R4V3IlEaXjxnYTfo+VJBQniBD/T81wIDAQAB"
-        }
+        },
+        "url": "https://raw.githubusercontent.com/blocklistproject/Lists/master/adguard/porn-ags.txt",
+        "format": "Standard",
+        "support_url": "https://github.com/blocklistproject/Lists"
     },
     {
         "uuid": "FD176DD1-F9A0-4469-B43E-B1764893DD5C",
-        "url": "https://stanev.org/abp/adblock_bg.txt",
         "title": "Bulgarian Adblock list",
-        "format": "Standard",
+        "desc": "Removes advertisements on Bulgarian websites",
         "langs": ["bg"],
-        "support_url": "https://stanev.org/abp/",
         "component_id": "coofeapfgmpkchclgdphgpmfhmnplbpn",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAoqpe6QWKketr66AW+hKSxr5qds9gxmU72N20bG/nG8wfbPUdTwEqIG3m5e37Iq1FI0gcQir5UqwZZUgkum5dWJwgCB1SOaVvlZrWZbTbATKFcePswHqAIXMfS+wzMA/Ifoky26dE4k/rs6J/zQEbeXXon/ikjGJ7GxYeHYMBz9DAPQhcUoBlh1C0O0vhvXU+kG5DO4wdIt9W/cXJtv+8OTZ6HiTJw1j0jAliFZI/jhkYB6MW57OBpBYlWJQhMbLbK5opXq6d4ELbjC1amqI1lT3j5bl0g1OpMqL4Jtz6578G79gMJfxE3hA5tL0rGU3vAmwck/jXh7uOOzqetwdBcwIDAQAB",
-        "desc": "Removes advertisements on Bulgarian websites",
         "list_text_component": {
             "component_id": "fdmemomgcgpopbhhmdkdedkphkglhopj",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0Yrj54S5rhxkhRCeNs0zpXclTFpJUmBKcPIYEbISsmgfGIKwd0GpR0IGxdENuSK4hEzFBpsQLLRcmipEHrDuqeaeaCkyLA7oBsb5REK4nBgsAB7YBekrEQQyOzoEG16RGqcIHw+0ZTppDPmF4Cdidyn9S77U481+W2bEWOp+NpFqPamA5pBaUyXeLgTB6dBRuUPnjjuXwZRF213W8HMI5T0c9HIuLipW+P3F7PhxD84F70dhuCUJ9X/DCjc5CFlWw1UPu3dlHT/sd15qR9glld9I0yGEXgQuPccZCBhnCWLfslaqZhgImmfqI1YBAzOaWED/q1y5hgh/8ru2RjOQ/wIDAQAB"
-        }
+        },
+        "url": "https://stanev.org/abp/adblock_bg.txt",
+        "format": "Standard",
+        "support_url": "https://stanev.org/abp/"
     },
     {
         "uuid": "11F62B02-9D1F-4263-A7F8-77D2B55D4594",
-        "url": "https://easylist-downloads.adblockplus.org/easylistchina.txt",
         "title": "EasyList China (中文)",
-        "format": "Standard",
+        "desc": "Removes advertisements on Chinese websites",
         "langs": ["zh"],
-        "support_url": "http://abpchina.org/forum/forum.php",
         "component_id": "llhecljkijgcaalnbfadljdpkpbehakp",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyahWbgHuWAI7CkBdclxOlehPVVGuG8u6bPi1vs016Kbhn9GThEVIP5qzAFQLA3jRrGy5B2nncdaCnibf7BkGsNR7nyQQuXAI2FGk9qCm36ZF7FI/yjtN0S0e6LzSswOcVhTdPnVkxYY6UDuKyzVRxgbF9Yg1aT45NFpJFZKFtKHexnLiY6KlZKV6GhY1jucjo7W77xdpLaspkYbQ69UvDlSA093InAzzikuqBdKvY0FPvC6pgiefqWTMa4M1cZU9IoIiukqrpXQn1tC9PJ8CU4XKCTshaNbpX5wxY10rUl7i/WHNcXCfmCXxKbqRZ1SyH6KiiBrDpSnfKXxrQip4GwIDAQAB",
-        "desc": "Removes advertisements on Chinese websites",
         "list_text_component": {
             "component_id": "hmnnhojoekmmehfpmeegehbmifiijobb",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxi6JL3FFNrYHPp90XALlCIOuC0/usN2tZF8oGdXe5v9KFQaNlvV//nJfYOiqyssh08FGsglQqekkUZxKdSsBQ8+7kPyBsrEepH4mWvcWNP68ONMjrY+onYM1csKXSe6aiQ+dN8CuJpcaTD5KJLBSCSGSfYqijkGshFUIHwpj7QnmBkdKzAChnynx88+c6lFIyMnxYjosXtL2Ioi/DFAVpb5z6+smNN1ZSo0lx3NNlCF/7ESN4SbLbCpcYgvs7mKuA4+i3/vQofBHY+YFy4WnGQf3l+QTRNk/uV7J9IKb/11U8i4LqxZ6ila4Ni/6JFzaQBfrvt/Nhy1g2Jkl9oWBNQIDAQAB"
-        }
+        },
+        "url": "https://easylist-downloads.adblockplus.org/easylistchina.txt",
+        "format": "Standard",
+        "support_url": "http://abpchina.org/forum/forum.php"
     },
     {
         "uuid": "CC98E4BA-9257-4386-A1BC-1BBF6980324F",
-        "url": "https://raw.githubusercontent.com/cjx82630/cjxlist/master/cjx-annoyance.txt",
         "title": "CJX's Annoyance List",
-        "format": "Standard",
+        "desc": "Removes additional advertisements on Chinese websites, may break some websites",
         "langs": [],
-        "support_url": "https://github.com/cjx82630/cjxlist",
         "component_id": "llpoppgpcimnmhgehpipdmamalmpfbjd",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAudVtKg3tZbgealGvVzbEL3yP1YWdt6GRDreqy/b3kCce3AZ8WroL8jb6Zj/aapBRCNxBezXzij+b6QiIH/l7sn5Wf5HDs5Vnrx4fDvGRtSLpgP0cSuFGVDx71TQz4X+AnUubOeHskIlJJAT4t4cHWs9c7EAl3ShG7DtvL2qHG2TUfJFqYOMOtQd2qG5H+X9zAUFP/qRHT55gzce8h+SXCsvdK4B8XK1cdvbIykllbGPzZr/TANn9gCtMKxUfk1qFn1uYD6mzg80KJmof8MHbLon6KLMqywcqfwEwvoivxo6f5LkOUjhqDYZEQ5la3h7lFfHKz7fCE7FCww7bQ028lwIDAQAB",
-        "desc": "Removes additional advertisements on Chinese websites, may break some websites",
         "list_text_component": {
             "component_id": "npcnkjiaolpnapjleimicclmdcccoeme",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsfs3LRQT1thqn9t53KmWtvaKeuBv7mH5ydazOFixM3Uutz83/PZ3Obsvux1/8JHDah6AvxBQtjoZy8jFKZNtqiHXxvkisj5DAL/O/rCwvZBHTXLQqodBxsCpnjAwGG9/Rqw1kOwKAb4hIHy+5Xq1hF8oj3eHD8WnIhvblOMYg6L4gVSCxpJOchPVLs/5K4sovGDxItmsJJqLYrsxtuqvsatQFj+GigrMoOAA3yOPIJDgr4/E+nqD9su5c7+3OPggr42B2+we9rwWiDCLQvXOiV0NKUavlV8P/8AbX0TG4RxTNEUTpGkGkyEzO+bCWV5/Ne+s8ifz9Bw68xW8zaZ22wIDAQAB"
-        }
+        },
+        "url": "https://raw.githubusercontent.com/cjx82630/cjxlist/master/cjx-annoyance.txt",
+        "format": "Standard",
+        "support_url": "https://github.com/cjx82630/cjxlist"
     },
     {
         "uuid": "92AA0D3B-34AC-4657-9A5C-DBAD339AF8E2",
-        "url": "https://filters.adtidy.org/extension/ublock/filters/224.txt",
         "title": "AdGuard Chinese List",
-        "format": "Standard",
+        "desc": "Removes advertisements on Chinese websites",
         "langs": [],
-        "support_url": "https://github.com/AdguardTeam/AdguardFilters#adguard-filters",
         "component_id": "lgfeompbgommiobcenmodekodmdajcal",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtAMyjMBZCbqNIuO01ZFJ5iKmcNFuJHXIUqhO9s6j6XnBAfak/OOk4s9k3maXyhaynXVpYATQyRHR0OEpmsQawFgKCmVm1LB68jxJ5Hh1ZITG1UyfznYnozkjBtzdkMGKeuZFBaHo5PPueHVO7yJDHvU3UFW4vCJ01twXiH4y0qaYjL1CPr58J9U0oKxptsfwEC53WcDq6mKtAKRpyxN6vbtFJ5/li2yC0Ms+8Xe3Xv5ovniM/4vNf3Jn1w0jzgrDRcW2VhxpydsH6q7oaR2igIzJ+XG6/k0g29CJhfT85dJNF31TwqvoI+Ju6hjZrEmSHmC7gbY7gN3ak+DbUrQxjwIDAQAB",
-        "desc": "Removes advertisements on Chinese websites",
         "list_text_component": {
             "component_id": "fbljdmoohhbifebddjnbbljgencmpjlb",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnqEZcpRqGk/mgGi5UC2hZSMDJTesTp/trL+T56MTsS2Ld6ktt7NOSoAeUNLjVO2kc840jwtUkgBTO93SOkaC4j4GuVU1mH6hGaGrvAGCEQgcBIIBBsCB1HUUFmWMlaOK/tRrysZ/ugummrhVicxdzYUK370dK2dj13WN68AR4Q2Hvo9gEdbhlG1o0YiGew5zF0BvmqoMK0owZIxGs5Gqq3enGqURU2FtlDBu7Tmfnr/Ep5l1KOSG87Gk2wlYR5KhkX1N6p2/EI167udioZK9CndnxqEIVq+DuYR0obwouV8lzxInZ07ojD5kW3O+WSlcRLCzCaRPFhQMMi7sLLxqzQIDAQAB"
-        }
+        },
+        "url": "https://filters.adtidy.org/extension/ublock/filters/224.txt",
+        "format": "Standard",
+        "support_url": "https://github.com/AdguardTeam/AdguardFilters#adguard-filters"
     },
     {
         "uuid": "7CCB6921-7FDA-4A9B-B70A-12DD0A8F08EA",
-        "url": "https://raw.githubusercontent.com/tomasko126/easylistczechandslovak/master/filters.txt",
         "title": "CZE, SVK: EasyList Czech and Slovak",
-        "format": "Standard",
+        "desc": "Removes advertisements from Czech and Slovak websites",
         "langs": ["cs", "sk"],
-        "support_url": "https://github.com/tomasko126/easylistczechandslovak",
         "component_id": "omkkefoeihpbpebhhbhmjekpnegokpbj",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuYBXbfloR5HddFlg80U8+pf5TqfFJQAf1bL4myp9KfGggwqrjuRzIkPOD8J8IvCp8tWv2f4QK9sAPHhtV6w1cnYX24lKxrQ/lHHAV6/CEcFa+2Yk7cRLKDC10H3r4FMRoCeAy/ruTjVPfIw+GuAfFYl1qYWBNxvW7XXw7cCIIYL4j82YQF6HjsWbTT+QHLCR6h66wvIyVQC9ppjJPxDaEevjt4tohEFAB1NBC+Wxt8H/P5r5ayNcLnb9Ygt75haYL8VWZOJhO/neSTyuidTFG5ox2Ruc6TXP8t0IqpVtiZUDkx1jzUakIHoKNMBc7oz3P/SQ4AanZsIliJobXFeUiQIDAQAB",
-        "desc": "Removes advertisements from Czech and Slovak websites",
         "list_text_component": {
             "component_id": "oegebjahecghlckbhkmojgnpcgdeajdi",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxtk14SdoCDoN+0991kgseVmUETwAVlWN+IHmyX6VM4fd4Jw4eRk5fflxBd4EsQIJQ9hCDxO/jW2YlGvz09Aj45OuxZ/A4T1h8w1IwyEJOc6NvkafVVaR8kvzlYq1sYsuPDiC3ACMx/AvmHTRoLDtJsH64H106ZjvMb5NzeJrhnu37Msc9w2tnmtc8XsX9RzTFnqp0jDeboOYoDiBtEo8DFSzI0CT3ffTMK04yKh/kdnslxTESHyDS69jo0SFRT0yVGH5xlb/N6FIqtB2fROlOrn8jGlr/3iufnvrKylRdMzx1aytHSK17yJiJe+P4YjlH4kjpFMTJAR+/I/SpiDu0QIDAQAB"
-        }
+        },
+        "url": "https://raw.githubusercontent.com/tomasko126/easylistczechandslovak/master/filters.txt",
+        "format": "Standard",
+        "support_url": "https://github.com/tomasko126/easylistczechandslovak"
     },
     {
         "uuid": "E71426E7-E898-401C-A195-177945415F38",
-        "url": "https://easylist-downloads.adblockplus.org/easylistgermany.txt",
         "title": "EasyList Germany",
-        "format": "Standard",
+        "desc": "Removes advertisements from German websites",
         "langs": ["de"],
-        "support_url": "https://forums.lanik.us/viewforum.php?f=90",
         "component_id": "faknfgalcghekhfggcdikddilkpjbonh",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAu1CpR7Asj+2wl/1vM39WGUrHQ6vT+nuo+XSL7VzTaxW7g7el5lUC2X9MaaynfK7gOblr5Wnf/mjSJJZA57mxogjOCPP8lF0c7sOEgeO5L6hnDGB7sonCEFpHnBEn8VOZDvmqEb++AiXUPBFSnAOt4Mouck5CY80N6Sqbt4cxUBSof/NsGHZiTvCN7fJpW4ajLOtbWhCAmBhdG0VHatBG+Et/Z6yQtxEYQixKQNHJljiq55MzuE2jfGOZ8MAjyQdstF+GGfF6WPqnR5fd1rECK3OsI8zV9OOLPkjKrKEnlMsaMFFFU0T7Ly1UALehlWXtunelzq1mGvVS7vV+5aVR/QIDAQAB",
-        "desc": "Removes advertisements from German websites",
         "list_text_component": {
             "component_id": "lfmefmifdjlfneapckmpkinmlofjehbp",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmvTOXmS56FBoh9eAsPUIAFXAYnwmyJC9HgLEtF7D5pkac6WkPAOOeidY+wJ0A2u58hBYw82f/8COkznUUiq7Oubb6+zdJP7lsTYbhN9yoPm+aw1vLucSa2O+O9Xhvp/0bT1bABtdccb9WrRT5HlL+BiHtwwHVZ0KLuX+k1IM6jxWD3DxKk7mnADxIOobODspLGkmduTMzVYygbMKf+0p478Us99aqK8oEMMjTL8IMHfdwFUrTBBbhS8mVkioNUFCEzeXFowhnWeoN6ysjmIcNN2STeVptCBXcaOAYePCrbCDcRzeOTBr4mu4U13Bune87VC+WJkTf+E9BDncTHjGUQIDAQAB"
-        }
+        },
+        "url": "https://easylist-downloads.adblockplus.org/easylistgermany.txt",
+        "format": "Standard",
+        "support_url": "https://forums.lanik.us/viewforum.php?f=90"
     },
     {
         "uuid": "0783DBFD-B5E0-4982-9B4A-711BDDB925B7",
-        "url": "https://adblock.ee/list.php",
         "title": "Eesti saitidele kohandatud filter",
-        "format": "Standard",
+        "desc": "Removes advertisements from Estonian websites",
         "langs": ["et"],
-        "support_url": "https://adblock.ee/",
         "component_id": "fnpjliiiicbbpkfihnggnmobcpppjhlj",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnrl1tavPfozqu7CmqNfVUtZfUlIitbWpFBRn+HVW0oEFUNqAwNlwHqy9QZP88wKvb5N3EJj6NAq6je4ii6nMkDn59teNzGA4m8QSkeOWT6pNm98FZA6HNHPnhnYSG2sT8tpQ8Uyh4ySrxj2ijVM0Hc01WKQ6zjkvZWOuZWllsCejRZmxGOLUUy5mtKhIfHiuleZ7AmKx46AiVFvrpvV5x8G2HKAlF/uDc6LmV0lfXcROt5RlY+kD/sQ6wKcatibpHbLoRHOJx3ac13+pvt85773af0MdrvdCYjxvqn3DJlKw9qqk/B59n+XdTmWcfC9k77Z0teoMM5EBy8G1nGbelwIDAQAB",
-        "desc": "Removes advertisements from Estonian websites",
         "list_text_component": {
             "component_id": "dcfccddjfmckaigemleendolfmmaaiii",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAx9d8o+kM4IcgkHERTS82gnn8jdvOaTqJ8YPV+vbiOEzS3ntIawegkGeGB5ZQzxqBdV/v17L1cG9Ze5RvqdHw2eqiRPWREwUw5G3TvvH4NAteGtx8+9xv82s+Vt4skM4bUfvm75uroz4wpAFpCwgpHnR3w8m3cnq4vTog/z4xVd6Z2cR5VSbuH/9S9RoboyLrse95XxMlb4mLDi+vIf9xbLrOYTknw3LQNrSb89+LL90h/XeyDHuHkfeqfAZaJ3g3E50u45nFhgHQQEz4V0vg1jL2PMmQmm01MrZCeC6o3FbTZXHReH0X2EDgaxhi/nq4SSYlPLuCvuHIQAojGu0YFwIDAQAB"
-        }
+        },
+        "url": "https://adblock.ee/list.php",
+        "format": "Standard",
+        "support_url": "https://adblock.ee/"
     },
     {
         "uuid": "AC023D22-AE88-4060-A978-4FEEEC4221693",
-        "url": "https://secure.fanboy.co.nz/fanboy-cookiemonster_ubo.txt",
         "title": "Easylist-Cookie List - Filter Obtrusive Cookie Notices",
-        "format": "Standard",
+        "desc": "Removes obtrusive cookie law notices",
         "langs": [],
-        "support_url": "https://forums.lanik.us/",
         "component_id": "lfgnenkkneohplacnfabidofpgcdpofm",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqNcRp37CBZCXe1vbmXyobycPxHyEKNIgNl6p0XBBxtcZcQOijpY70GjCRzgCL7m1+FBo4MR3FXLiF2aPn/QsUR8t7+zfw3XzBVos4Ssexkqpd4/4ciASwTXpbuyFOq4Z5dcgJ1afeT9Zj5bmh4ekLpgJ1NzVwCMhEKk6cmSKIaGVo5EEydtlor2nkUJrSFuZA6tYZ++4BOfhhCtzrvXTZjg7mTlB6ca21NL4oLwtqvJMtF8ddoumh619BB5wOqxLzntC/oWyOxf00V5HDC7e/DRj9J8jLRFLd4EQUO4Mk+kG3MNy0ph9cqdw6zFR7a2H3LGkl4ejsifM1mUDuJL0cwIDAQAB",
-        "desc": "Removes obtrusive cookie law notices",
         "list_text_component": {
             "component_id": "cdbbhgbmjhfnhnmgeddbliobbofkgdhe",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4txGiQ3yLerqLDucoT7AeFjSShvHcUlEbW4XTf5Fg8qi9GzXVXSS1PLZZSYX94fIch+0gd0bFBsSuN5vJVjR/xIyYaS29uvav5WJ/p3zt+mqW1eDarQ3CS0rsqWHjeTQJjaqw/TY7zS7/QJFspQro6/tOAPivWXYHV7kWVUtpuX8vcLLM11mexxKUEcbTrFwTmF3aOZcQnCTTR1NFV46v9MxnBj86RZQ9v/APjDIt9d9l8/bvq5Jp4w+8sv5ctb6nxSBSrhyVlbYe2eVrdVwOrcKijGA1ROfEk4A/R8knajBl6ihiXlGteVqIOrka3onyB0y8UTP++a7TZey85yXUwIDAQAB"
-        }
+        },
+        "url": "https://secure.fanboy.co.nz/fanboy-cookiemonster_ubo.txt",
+        "format": "Standard",
+        "support_url": "https://forums.lanik.us/"
     },
     {
         "uuid": "67E792D4-AE03-4D1A-9EDE-80E01C81F9B8",
-        "url": "https://secure.fanboy.co.nz/fanboy-annoyance_ubo.txt",
         "title": "Fanboy Annoyances List",
-        "format": "Standard",
+        "desc": "Removes Web annoyances",
         "langs": [],
-        "support_url": "https://forums.lanik.us/",
         "component_id": "kfhcejhgfapmkapakabicnjhpglajkao",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAs5oODJ9Xh552zkLYW8nkCkzOQ0qBNGbhxf7sXwtJsOgQJ8D+DypeYWal+g63B28OX/xJ3Mwnd4WF0JWeN+i3CxBSidSwCPN6c7/DZF4xUyzpo1uvQnnBL6uYgzBYR6JJ904OVHFEgRM7MIdgve2Z9PyaWvNEEg8I2vqPDyBIu8GAy0UjG9edQLCAgQrmejpxBGXuB6b87FILMryW7ejbUjh39hFhpzu1pmsG1wi4jWX1xzaqUiF5xRPbuBx64BWsAzern4p8XdjH3mXgwJiHItBngcDh1tHKjD7Ke5LmY9gJf9TIXkrBPmiu0SAfVhcwmfj/VuWYa8R06cSaCRZF2QIDAQAB",
-        "desc": "Removes Web annoyances",
         "list_text_component": {
             "component_id": "omoaeaghhgmiojkeaemjkpkmelmalbgo",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAy/xbKx4WIC1LApciemKEs4rUz8MspYGqLzmhQwIsp6qOqMKiYA9pqOtUXx2TYRPkZODISGSsoqvTZ6Uv7Aerq0Bu06UiDy+H4yU0jFZPVDKsMfj9Ky0DAy7ocuetTIps5Aewx5S0S8g9zeI14PluhqsXlTMLQAqkFeUSsML0qHo94Zgx4T1AwHH8IjvsHB1456OCRjxlTICGL0hEwZdEV2rVYWXtkLzEDZ6guPmvEVKZIhey1DG9fXV57SFCLmBC2eTlv0rYDqqgK6KSUeqyAIHV4eiaqIPMgsRFVnE9JD/Q9xrjeAuFc3pslx4YKI+iuXgfa/8jGpPuKqcDX51F/QIDAQAB"
-        }
+        },
+        "url": "https://secure.fanboy.co.nz/fanboy-annoyance_ubo.txt",
+        "format": "Standard",
+        "support_url": "https://forums.lanik.us/"
     },
     {
         "uuid": "7911A1CB-304E-4CDB-ABB3-E2A94A37E4DD",
-        "url": "https://easylist-downloads.adblockplus.org/fanboy-social.txt",
         "title": "Fanboy Social List",
-        "format": "Standard",
+        "desc": "Removes Social Elements",
         "langs": [],
-        "support_url": "https://forums.lanik.us/",
         "component_id": "jkmfbjpchgojnebkdleeiplnaagomnll",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1COQ5BWnYkWTrXeLhmaFQPHhCGbQ8gXNjd55TQxl2ne07PpSd6We1LeowFPuMrgXyIyhzW+MRxndFYhjMsUyJ34N+GGpDBf1u6zKWkbtprVgFhWDrlzmfuGq0o1SFkOo5bA2h4MhjBIJG55SuM0Bj6hYNtQqqQbcu8wC+L2glP7XtJUawUbZCr2eGFEDxBJA+g4HOgGAhAbgM+1xrL3IMsDTI1QChPjotTRxlUzARVWYMJN/r1Dmu8+pkmsgNfvVcmbLxqPpqhlKV49VtlB0QI0tZMYSIqui5B6qku6XJk7SUt1w0jZ+A5LpcQtDyAnlcnFwi6wqsujhPZ9Y4rr4GQIDAQAB",
-        "desc": "Removes Social Elements",
         "list_text_component": {
             "component_id": "nbkknaieglghmocpollinelcggiehfco",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAs6ib1E68QTHuz/TdEn+ck++Okbcf5xDfQjkhpTb59fnjm0rjII6MV3rWLEj5dkOvpAVzDzFCcyC/JJ/SYIY7nFRQl+ptttd1nLWNu7qewFGh2tezwuEMzPlzQr+KK93Yh0dooCC9KniR/0+kpYeGqBC8tBGz8f4KoV+/zTfkD/47pztflCxNJfrAj4P0GDQhvz8lBtnm6Pa7tGOMhksnMsYWRWsYs6uvjsfd+3uYbiCYa7lEMjZZKy7dHg8hPSUeGZo28kTqYFXufH5jY3q7Luk+dQey1+m1X97KLPOtmwaLFCFqWBha5qFMg/mgzczlaphReFUycwrYVjjOICKrYwIDAQAB"
-        }
+        },
+        "url": "https://easylist-downloads.adblockplus.org/fanboy-social.txt",
+        "format": "Standard",
+        "support_url": "https://forums.lanik.us/"
     },
     {
         "uuid": "690FF3B4-8B6B-4709-8505-FEC6643D7BD9",
-        "url": "https://secure.fanboy.co.nz/fanboy-newsletter.txt",
         "title": "Fanboy's Anti-Newsletter List",
-        "format": "Standard",
+        "desc": "Suppress website newsletter popups",
         "langs": [],
-        "support_url": "https://forums.lanik.us/",
         "component_id": "jniglbhheddihbcebineofiaophapfcm",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvKrGZC8Go3yIWQUdbOJs6mcAftW6rzmZEO51woVeBgEtBO7KWkMqxbVF0XROE/gsQPThCtFLjG7Wl5vLxNHK/8TgCeju/4qB4hVcXkss+aZ49KvgFzb1aGlm7n42aOpnpJ2WOCsnnHbJAPSHA/k3KixUT+xl772QdHE4YWueWQSHSuhdOZ9L9e9NErDtD94qwTxeYuDNC4xBHp+CXLG4kBah515by4kJ5242exRaK/OcYWGAXHSnZDqQ2/fMmM1wfrKsiln25+lSBmYLBDjqVwPxr3nMdEqE2Qurqmqee9wGCVNEjjkoNbyGTgh9t+eBJoOF1YM9kAAYTCbCMbMXIwIDAQAB",
-        "desc": "Suppress website newsletter popups",
         "list_text_component": {
             "component_id": "kdddfellohomdnfkdhombbddhojklibj",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAr2V5xKHqddrLQr8mNlL4UQGUYfK62ftOlacYb23wPWfW1We4jIOHtYqHg81D7gYckSBejkLh2HqmGa6RxehFTQf8g/L8G1dgzQ10VrQF4STNJiva/EkhcEJHai279biESL6HLVTDun2BnXENxCUR7hc8hDM4xw2ZlaqMMUtFJwhQW96dzbLVG3yP7k8TDwX1dRaAa/Pe+Ie7OYhIUQp4I3rWn3GmhfKBxQalHce/7lQpZwCP8Q/Tz7D8GzvMu+dYm5LnP7LUfC2SdSM0jm3qqwKkWlT1W05tsce4vk2cnxwUUWOAh60TSzQ1d1DX/PfJBUzQG6gkWRMxGNLi+T4i9QIDAQAB"
-        }
+        },
+        "url": "https://secure.fanboy.co.nz/fanboy-newsletter.txt",
+        "format": "Standard",
+        "support_url": "https://forums.lanik.us/"
     },
     {
         "uuid": "2F3DCE16-A19A-493C-A88F-2E110FBD37D6",
-        "url": "https://secure.fanboy.co.nz/fanboy-mobile-notifications.txt",
         "title": "Fanboy's Mobile Notifications List",
-        "format": "Standard",
+        "desc": "Suppress \"switch to app\" notifications and prompts on mobile",
         "langs": [],
-        "support_url": "https://forums.lanik.us/",
         "component_id": "ldbgldhcahahpffloggbbmjllggnkenk",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAm42LAwZhmXBZ23uRGC8btPLv16YUr+9NPd8X4R1TVIMwujFBmAAVDVKR2UT7Ma5FfmdVimr/LxIv3v8DtAlnH5KZCd76Rtq5iYxMlPmCS0QKE42zRK/3u0ezN+/U9xAKHZQviw/Jn+go0biuiEmxzbFlAHNvdqaGtvHwBz24/DzWr+sRYbS2ttk31E1PVWF0un+n4ivTyYRZ6J6DLN3Cl+nPMYrmoyKGVbVLZcWHdftGjs2CGvyIYwlpo/03B1NahA1BrZvEvuL+xuqp68Nx7LAG2MHGeHTFkKYtcqr9gQR+W4EsKrQKCCJ0NEe4VralIVxn0Zi8wOQ4a6127uP7vwIDAQAB",
-        "desc": "Suppress \"switch to app\" notifications and prompts on mobile",
         "list_text_component": {
             "component_id": "bfpgedeaaibpoidldhjcknekahbikncb",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA310+gKMk4QUl7K23eSXHDukkg1Ped5At02N11zRHJf52mTFy6jnUgA7vo1hkARNHHJDwI9dSyfYsAtrw9qgo/V9ygDBkgShHyYC7c08pgUkdlciaZepj633yuMyyFK9lo3PEF+f1kOodE/Vq4ybJTChDcotuT5bAi57d1Jiizgv5Rz4W9ZvqsWOVbiclQTY+28wTpfuCLznV7mrx7kvm1D2aQaLaJ2R/936DkXRqUn8Ty9GGGaHqx9HK2JgB5RjwFk0esarZyua0kRB5JwMUGu+TsEiGgDpCbRka3nfxItwhoWGBYPwdapkdUr7l3RdeTCLUWmCBdkpmDMhbrG3ctQIDAQAB"
-        }
+        },
+        "url": "https://secure.fanboy.co.nz/fanboy-mobile-notifications.txt",
+        "format": "Standard",
+        "support_url": "https://forums.lanik.us/"
     },
     {
         "uuid": "1ED1870B-997C-4BFE-AEBC-B67D679BAF3B",
-        "url": "https://raw.githubusercontent.com/easylist/easylist/master/fanboy-addon/fanboy_chatapps_third-party.txt",
         "title": "Fanboy's Anti-chat apps List",
-        "format": "Standard",
+        "desc": "Suppress website chat apps",
         "langs": [],
-        "support_url": "https://forums.lanik.us/",
         "component_id": "obkanklfclekjgmfajnammibdjcbeklo",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAu3bU/oJ+EYAfClmZsUjMjasCBbw+9YqkeLdsX3xtJuZ4N4o9ELvjytMoCi2dsl+BDo94C5zheZOEtLvQi/C/z70uP0bbNU+uST8R+hMgtcVq91dRaUmZUpfeBiYA6fK8svko4VK1dKX5ruvicwuE1jp3MsfKwGzplWsjUcolVjzS0JH0VRJu1Kl7uW/sMbCfVWfg+6YIhpHNGxgaZF48U0lChMHw4h4YH7Mf34QHDKp1p6KD/VaACmmdlDepq8LmzRT+T8PF4XIS+YVdFkSf6BwdP+APCFLAWkkBctUsgzQk5oqrnlm0KekIszp8UEgd0gyLgC3Rj7qh5XVSYFn3HwIDAQAB",
-        "desc": "Suppress website chat apps",
         "list_text_component": {
             "component_id": "cjoooeeofnfjohnalnghhmdlalopplja",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAv1O0sayAdmrsaqTddCEZwwHvpjjCbR/2qYj0xh9FsFMS17yIHpZRTZw8F8b0NFDAb/hIuIpNeaBXZUN/oPG9eWv4GoV0fDIr9UST5WzB+zPBYgSV1S8TkqLnkDvE5sTmzG98sd3VL/L7PeijOCidcKnSyG5hkP+UNHmKUaRnLlUTM/ificlkjR8IKMNFrC+e4PjHkF+EtBFLKR9Qb9iEJHEjDbjEgtozDs3IrGGsrK3WF4A6iqD5zMX50FvUAqPkAhm9jnfyISarfwkI5WlhQ/mmA0c/U5lXFg5v7MoLR05ns9G40jqOc8jFmzVaayBVF/7RaR9wxVlxEzzMDoA37QIDAQAB"
-        }
+        },
+        "url": "https://raw.githubusercontent.com/easylist/easylist/master/fanboy-addon/fanboy_chatapps_third-party.txt",
+        "format": "Standard",
+        "support_url": "https://forums.lanik.us/"
     },
     {
         "uuid": "1C6D8556-3400-4358-B9AD-72689D7B2C46",
-        "url": "https://raw.githubusercontent.com/finnish-easylist-addition/finnish-easylist-addition/master/Finland_adb.txt",
         "title": "Finnish Addition to Easylist",
-        "format": "Standard",
+        "desc": "Removes advertisements from Finnish websites",
         "langs": ["fi"],
-        "support_url": "https://github.com/finnish-easylist-addition/finnish-easylist-addition",
         "component_id": "kdcalgmhljnckmnfcboeabeepgnlaemf",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3seBXoyYSdtiqNAIaS5v9jP6Pr8xqgFnZyHknxNsC92fHyRW2nbuwMr78pWA4vPIyV6BFG5jS8k2RXEbWiOKNNsw7nWlfT4QMwkEu4uU1vqxsNDtdc1rdrc69aBegyNOQBS+W6aP1ESHp68AoalYKMHKpc+fi00sdQwYU9Y5oW9q4uRX3baAyuGZjP0xuKN3t+T1QnhbhkldP2WP0ooU/VRMhy2rYoE+W6eQRGrghJJG/wWznz5AiPD9EpPST/hoVWOKVco+12IbdILw7yGX2c65xPcLr6obVR+549QrgxU0W02XxS2lXKGc1NT2Zdl6ugh6XpW1RHVz7SjLIZgifwIDAQAB",
-        "desc": "Removes advertisements from Finnish websites",
         "list_text_component": {
             "component_id": "afggnigkiebjlahlhcjgjahbhfikcipa",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwHc3AWJORkPvjY4vthcP1CaLpG5yIga3gADJP4jAfRaqcxQp9f1IIGvtK9+nUerpaomRMTjJYNm1lQk0uq9EAcQjdb1JWl/MOh3OGlhZ3oYLTNqMW/ZbMHrfGgGD33WXCcQElu1nNOHUxJqaFeyOZvI/4LumYrlpADdotoVSJ1pMhrj9iQg+a/GAddBaAGEqYpjF4tNBGPTufmj5L2Grh6Uaue5sLFzH9lNi/VYSlCcXRDrz97EO0tjyNrEQWffuamAAd/ArKDSdjvfAeohGEyTeR5xPq5yysxBQqzryWK17fg9MtS0ZIGBbSyAwT8wctJ9XmpMnGFRL7sXqpYb6eQIDAQAB"
-        }
+        },
+        "url": "https://raw.githubusercontent.com/finnish-easylist-addition/finnish-easylist-addition/master/Finland_adb.txt",
+        "format": "Standard",
+        "support_url": "https://github.com/finnish-easylist-addition/finnish-easylist-addition"
     },
     {
         "uuid": "9852EFC4-99E4-4F2D-A915-9C3196C7A1DE",
-        "url": "https://filters.adtidy.org/extension/ublock/filters/16.txt",
         "title": "AdGuard Français",
-        "format": "Standard",
+        "desc": "Removes advertisements from French websites",
         "langs": ["fr"],
-        "support_url": "https://github.com/AdguardTeam/AdguardFilters#adguard-filters",
         "component_id": "emaecjinaegfkoklcdafkiocjhoeilao",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsbqIWuMS7r2OPXCsIPbbLG1H/d3NM9uzCMscw7R9ZV3TwhygvMOpZrNp4Y4hImy2H+HE0OniCqzuOAaq7+SHXcdHwItvLKtnRmeWgdqxgEdzJ8rZMWnfi+dODTbA4QvxI6itU5of8trDFbLzFqgnEOBk8ZxtjM/M5v3UeYh+EYHSEyHnDSJKbKevlXC931xlbdca0q0Ps3Ln6w/pJFByGbOh212mD/PvwS6jIH3LYjrMVUMefKC/ywn/AAdnwM5mGirm1NflQCJQOpTjIhbRIXBlACfV/hwI1lqfKbFnyr4aPOdg3JcOZZVoyi+ko3rKG3vH9JPWEy24Ys9A3SYpTwIDAQAB",
-        "desc": "Removes advertisements from French websites",
         "list_text_component": {
             "component_id": "flnkmpokemfpaajmiimmjeiandgoodgg",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwwUZwUB8V3M17u9iE4xJlqee5tpabVHr4SUZJMdcxUVYi0gPLSQfWHNUR9HqXy4/b92OmPwOHcp1d7gereg8ave7d6syQB3R6xZLM04ESK949zUAzuYGmTSGPgBmC9O09tAw+dmHrHNXi2zKUf/bU0nOXyYtRqPq9UYxIIxq51nqgIqvUdvX2iwVPGVEXOxgKG3zCF8Z4U9tImWYYAq2cb3LbM2+b6w++PsnhwN6XIFFV2KsYVhtrOnzpgE3M+1cI2BT6N9prYIyP55MHfvU7La/VfqgmRVjH+qASJw0kGy1T/c7R4DLPHaND1L0MY7GjwRxAgPct3eTha+weL01vwIDAQAB"
-        }
+        },
+        "url": "https://filters.adtidy.org/extension/ublock/filters/16.txt",
+        "format": "Standard",
+        "support_url": "https://github.com/AdguardTeam/AdguardFilters#adguard-filters"
     },
     {
         "uuid": "6C0F4C7F-969B-48A0-897A-14583015A587",
-        "url": "https://raw.githubusercontent.com/kargig/greek-adblockplus-filter/master/void-gr-filters.txt",
         "title": "Greek AdBlock Filter",
-        "format": "Standard",
+        "desc": "Removes advertisements from Greek websites",
         "langs": ["el"],
-        "support_url": "https://github.com/kargig/greek-adblockplus-filter",
         "component_id": "pmgkiiodjlmmpimpmphjhkodjnjfkeke",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4KGRug8Rw1WHk1BPfIdtdw7uwFijUac7jk1lb99lEfSq2uPV2bKCk8lLh/6ahlV/EjSN8mGiFfZIVTDFhuYhVuIO8iETrCZe1ChoI0F8ptHOPQXVPzKUFMpkRqAnH51vqx+3gG78A3+iGfAE+LjerP1j4Jx5jSvTkbN8l+RqKMtjaaL9qRHv3aRQtYB/shGgdxKeOR0f8E6yJ4tIRDHB72bDufN7wbnRoHCNnLkrAPtbIwpWRLKYcOxAB6QqKNCLx/UX/pWpGtyJmMQQBpxQgl3BT8daNp0h4Soc6VPZA9wEIQ5/a/8UpsBT9rwJGj5WdSBPSR8D54aULATPxsienQIDAQAB",
-        "desc": "Removes advertisements from Greek websites",
         "list_text_component": {
             "component_id": "onooookdmjmijocbeafcldnbfiaobhjk",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAs3sUB/utZpzoNR8aq6FlVWLtCcYC3cl6V6mX1Kg9gUZBCJF4iH3YKlE73lS8zaCO0jnaALUHX2MUFtZvR2qXfHxxiZdlBmGMGfMMqwaTwbRMW0NwhkXfAc7MW3rD0gO0o/FKqhBbc64WefI8TCKwWFSpJCKgBrZK/b3eTWJBg2kv1Zwqd3fB30j4pbi6G8Q+7nryRC8LAY6f+r2MneBoKwJBEXynkq4RJuj6xVaBZAlLoBTn/166tQaoOHf3L9L9CvzpElprKPpC+k3oBTuJqdQXqPafilhpt6ooHnbiBr1LDrV/jHG+YZ0AA5Brjw26ipi5jSn864VsCysGwoLYQwIDAQAB"
-        }
+        },
+        "url": "https://raw.githubusercontent.com/kargig/greek-adblockplus-filter/master/void-gr-filters.txt",
+        "format": "Standard",
+        "support_url": "https://github.com/kargig/greek-adblockplus-filter"
     },
     {
         "uuid": "EDEEE15A-6FA9-4FAC-8CA8-3565508EAAC3",
-        "url": "https://raw.githubusercontent.com/hufilter/hufilter/master/hufilter-ublock.txt",
         "title": "Hufilter",
-        "format": "Standard",
+        "desc": "Removes advertisements from Hungarian websites",
         "langs": ["hu"],
-        "support_url": "https://github.com/hufilter/hufilter",
         "component_id": "gemncmbgjgcjjepjkindgdhdilnaanlc",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4HNXDsDBPP4b/irxacZMYnaPjNMXS31e11nsFBvN9lFOkuwF3bEk9uEk0fDzocF6GSpXbUE0HVTqfKTTnZfvG9m+C3nT8j6N7BB/wST72s0zXCjSlLWJPGmFnFb/EDkFAGmA9FU4C+j28Obehd94OC9pSqu8DYK4LbMWPmk2fgpO9N3ZV/5Y2Ni69WKJwT72prSMzyVVEAYluCYPQWY93g6dJ9RBtwnHCmdK5TG/bN2q6f50Cw/aJSv8nshSdp+KJK6yi6fBOxF5Xb0Bj+xZGC4K4SW9JjElswaGJi2PX5I11w7xC24jNaW6BUHcJ6IXudIVmBFQxWWxkMVwfgqNlwIDAQAB",
-        "desc": "Removes advertisements from Hungarian websites",
         "list_text_component": {
             "component_id": "ldnolaledjfkfgpjkbkcfjiaejeeanmh",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA7xknL/MMlSEoLkHDXwyP7S9c2e9q2bYvfBeaA0ZOQG4O3hB0AInjki37iHINkQX/UAEprDDqwNOO0Xp/pWBWItrFYkgPmgfzoaMZ7PnwUiA7/+9Z+JoKJcqJTWI7VlVmUpeclWcL+hqdhcjVGdGK4Y8wupADUpasqsG0mjwlpQ4ur0+G6qJIvbYB95L6Jk1OjwE89RjxYQNPw0cb0bxWUDZ1uLSJHe6eMvMH4P6V8ihwltHG0FpZ6B9U2uV6r1KeTWCbfsWJJLPmzCW861/lSJtOSBynVcsS8m0vD+UHFZn0IbqoLOJZpqvtZCTjl5pC6WOY1TP39J5WoLJtXXO0mwIDAQAB"
-        }
+        },
+        "url": "https://raw.githubusercontent.com/hufilter/hufilter/master/hufilter-ublock.txt",
+        "format": "Standard",
+        "support_url": "https://github.com/hufilter/hufilter"
     },
     {
         "uuid": "93123971-5AE6-47BA-93EA-BE1E4682E2B6",
-        "url": "https://raw.githubusercontent.com/heradhis/indonesianadblockrules/master/subscriptions/abpindo.txt",
         "title": "ABPindo",
-        "format": "Standard",
+        "desc": "Removes advertisements from Indonesian websites",
         "langs": ["id"],
-        "support_url": "https://github.com/heradhis/indonesianadblockrules",
         "component_id": "egooomckhdgnfbpofhkbhbkiejaihdll",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAptA5jVa5JkYI2jt905om4OLSHGahwgS7tu7GG0sk1YNafOo4ajKrN96Kxj0fgwGrJPhU1UiTDmrgLTZSbuC3hAscbfhuakVNo1pyFfSAVoLWSrOq5l4k6zZK+y1ahxdyJvlbz06RWE6OhIqExxGqLyMjEknkPGxBVO0cKcYHiGYUxvVPxQOg+9fGieXMlSGs/L7Mty1oJOoZ4JcPIFeSvQ5ax48E7l+yAW6psNpPqRAZ5fm7hhZXjd5+3cfXXIMStgX3X0MUHjx2KpYlv3NxMjaZQOAZiuZ3W/H7VWnV7V/ScJ9Eb+e6iG4XS15f7vFQu4zPy4UTYOl6gXnIGWGmsQIDAQAB",
-        "desc": "Removes advertisements from Indonesian websites",
         "list_text_component": {
             "component_id": "olkjbfppmeijhkjhjjmfdbloighaigmh",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxNZ6zkktNhRLBkb0qCtQqkqt8mNTapW+0dO8s23+cjHz/pcVHOb5dIWvuF1OtyZOYFojIhx6GmTNPQ/RtwMO5TSwUbLQTHmN/n+e2/kalV0OO21SAXOG4C7myNGa3FClPRTY9vGmGLCtMGkak5I70CbaLrjemO27gxrWWi2C1vfYHzzCkt3wriY7ZE8Xo2SGZSJ2z52Q/xMJVviF2xXXnL56ZvpDifoM3KYMacXPMa9nzOvZ6KHXmmqHKFNl59LmujK1SH2p8sPbz7FykXVgfZedU8Ul7qfLWwGUcliLlALE6X0lLvEtiX60nz3dZIrvZAfagsjayDsCydf0lQ79ZwIDAQAB"
-        }
+        },
+        "url": "https://raw.githubusercontent.com/heradhis/indonesianadblockrules/master/subscriptions/abpindo.txt",
+        "format": "Standard",
+        "support_url": "https://github.com/heradhis/indonesianadblockrules"
     },
     {
         "uuid": "4C07DB6B-6377-4347-836D-68702CF1494A",
-        "url": "https://easylist-downloads.adblockplus.org/indianlist.txt",
         "title": "IndianList",
-        "format": "Standard",
+        "desc": "Removes advertisements from Hindi websites",
         "langs": ["in"],
-        "support_url": "https://github.com/mediumkreation/IndianList",
         "component_id": "jnnbjhbkmgggeoplhadmppaeddmeapla",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1KcZJ8dK2ANtw8x19l0g1i2sSsg/G6AJNLORsw+Uz9g6sx7pUJo8TpjyITiwO366C6q/I2KwFpuc0NgGvWs6nLMEX6yaGO8tnrza36Dj7GFTQA9+H0TQxuZdcOfZqP8UakA6exGOl0anzAt/HQB1Gf6ipKilS0M4PAnPwlVaTRmdKxQwqHQrpfWSiKRB3MBG/OT48y9SXKToP+NAIIfVRC7TxPVJ0zIu41UDfU3Mx6zKOBcRfTnhmUT9XIEv2lAfRDyEDXTGg3nSNluZM4Bu4iQKpxj+x7oZDpQMkrpVBZdjpIRMPiD6aMKCo3GULoH15Fb7re5RZLJIxcu0+B8lPwIDAQAB",
-        "desc": "Removes advertisements from Hindi websites",
         "list_text_component": {
             "component_id": "femdbljnkmindcakmnbjhfefepeaicnm",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvr/tGn/LAkKrRrt9PVmtyFvKMhSEVj/OuUsD3Jorj+U3TU06Akg8YkGg08rrfjuZjFTtBoniCgtQsnpIuCaRhN/2u95EkGxsS92932YjQQUDMw2chAWaaFKJI1bFSIvvuPAK1lT9RuW/Aa/rpOjDpAZiszVoVMu+ZGNvkheBVm1HbU5rPB24x2kdayzH87wcJS9GxApGa29cXUNUmCZw7w0JNqd76/i86SZBdjXtlPQz1LynLTGyyCUC2sqlcn+lVNVTkGA86EQwM/GTrknGaqyArIoeJMgoZ2WCOOozz0RO6RDPbDHemLE/9+ROHxFwtjhiXbSR+8bbUlKQI2THvwIDAQAB"
-        }
+        },
+        "url": "https://easylist-downloads.adblockplus.org/indianlist.txt",
+        "format": "Standard",
+        "support_url": "https://github.com/mediumkreation/IndianList"
     },
     {
         "uuid": "C3C2F394-D7BB-4BC2-9793-E0F13B2B5971",
-        "url": "https://raw.githubusercontent.com/MasterKia/PersianBlocker/main/PersianBlocker.txt",
         "title": "IRN: PersianBlocker Filter",
-        "format": "Standard",
+        "desc": "Removes advertisements from Persian websites",
         "langs": ["fa"],
-        "support_url": "https://github.com/MasterKia/PersianBlocker",
         "component_id": "dbcccdegkijbppmeaihneimbghfghkdl",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAm3AZE2ne7R55X2j6RxAQHAZKl1hNPgwLOFsYpfAJ6m0uXmKJspguWxatJ9jDBbYLmtXnwX2WORILq1+r4kFtTcN8GNYe7/7o5yDLucI/W9d2vCjmEg95v50MzVQZSwd2gNZVZtL1s0S6pBwX0zI+6kHIFr2xqGV/FNE8L75f30rriQ0xKmenI1OWjyn8gNqIp4mKZW6XxkMRRS9+e0ynDi4ysQA9Ub5YHJxm0t62eqTmIyemgRhP6Rdbi0+GXbqFPjDfC26rtD3wy5f3aYL1V+2ADpdDyCeNlwCH7+vC7LWujqNTgK8wVJ4eH5VbUKC1e9cm/T57OsHJMDC5fbUuswIDAQAB",
-        "desc": "Removes advertisements from Persian websites",
         "list_text_component": {
             "component_id": "keclkbppmfihehggeadflldbjpolcpgf",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArAhgRAugxeTTvhXNSRQJ9nE1mmECE9i6HgJjNhyG/XXIKWSzCcbu5wmjOPN11iLjNVHdLZMcKnAqgFbieAVxVRFJdWG6V//E5QZRjZ90g+OCgE7wx7W3BoJUynOWirGuaJUyYv8T6qvLqeYm6RtPMgrfZGxUJ9+PDWCtz0e0St09RtXdPhr4Ft2Yk41xda8D40rzgr+tnNo1FwSdysMbLA5xjD7pqSVNR0b/ivFt8S5o6klEifZywqlmNcfpeLFqhBBfNGGr6xIy0EGxo9HNjdQ5lrn9Cx/bL9kaKiYKuGOsERkSNfrGipnDMZqtTGSY1ECEXaY4IiXVkqYJ798egQIDAQAB"
-        }
+        },
+        "url": "https://raw.githubusercontent.com/MasterKia/PersianBlocker/main/PersianBlocker.txt",
+        "format": "Standard",
+        "support_url": "https://github.com/MasterKia/PersianBlocker"
     },
     {
         "uuid": "48796273-E783-431E-B864-44D3DCEA66DC",
-        "url": "https://adblock.gardar.net/is.abp.txt",
         "title": "Icelandic ABP List",
-        "format": "Standard",
+        "desc": "Removes advertisements from Icelandic websites",
         "langs": ["is"],
-        "support_url": "https://adblock.gardar.net/",
         "component_id": "njhlaafgablgnekjaodhgbaomabjibaf",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqSwaNKhg90HCheaJu3sHocbZUjXDs90I0OmijNkDeS291wUjvXAm5YqhNE8aZmPSMVZBjBCwKXrrtTOkMA1b1uBqJ2P83fCZsgNZWbGTD8MorMrU6vyqkWCqLRc+bTTUgzAd55ckUJ/M+HVnjo6QfqUuB3kVzjpwJorQQZUYOLcgDY/Q5/tbrXI5+OGVxAb21pmnk8JHXNNWB2NvpA2o3p0ke/7WEoUH24l91ndOkXkN87eO8rSysl07Eq7gshbednYYiCxRPjuX0aPqbXMYNWXa5NdvIXFJcD2xV/l/QvXRYl+7Ca1igSXaiKc5eJyKSRqY4lf2vG0XCH6VZVxZuQIDAQAB",
-        "desc": "Removes advertisements from Icelandic websites",
         "list_text_component": {
             "component_id": "oimegboipnkgekgoccmlljjlhhbjaoil",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA62u5aa9kHm8s001ehhl+tuEE0bSSUxxBPfpSWC7Xr9zwObVpq63bSUAQqgqy0RW4RIq9X2etSmtpYryr10FglhV3TvMhZ/JxAX9VcPolrgG+tdMO+000+S5T5N/qpgZB1IycedaHNQ2NEFBSZEU7wqTIqHdYjAerkX8yC13Qg89FxU73Ygkq+1hQl1ZUr18f2gU6WpG5Nv1hpwwNQKJ5mn9K4d9uE2W7croqFANvEcvG6teAnw2JCWi42uabN8Ec35nff2r3BPCryCuAx3bsInasbDHNFlww6HXHBVfBr88y8v4hursSGmKShSFBMM2IGcRaF7Sia9fWGyQkBjiE7wIDAQAB"
-        }
+        },
+        "url": "https://adblock.gardar.net/is.abp.txt",
+        "format": "Standard",
+        "support_url": "https://adblock.gardar.net/"
     },
     {
         "uuid": "85F65E06-D7DA-4144-B6A5-E1AA965D1E47",
-        "url": "https://raw.githubusercontent.com/easylist/EasyListHebrew/master/EasyListHebrew.txt",
         "title": "EasyList Hebrew",
-        "format": "Standard",
+        "desc": "Removes advertisements from Hebrew websites",
         "langs": ["he"],
-        "support_url": "https://github.com/easylist/EasyListHebrew",
         "component_id": "hjeidaaocognlgpdkfeenmiefipcffbo",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAoUnmZ/fnWAGhAywLBs5IX0OMxK6LOwtjljcwEkt8QD7ZKBekxq+MDrUuRPzav3ky9IyREhXe9F4UWBKPDD8ZQXZ57WQAAMAp3IxbgdAsTqqTEEReUVx+pzjl8lxdp7xEG2gpuM5wq7bjn4zJ3kcdj3vx7bec/YbYf4fV0brQPWghKf2sh3mHXOVh68wEFXYBvcWkGXfuBoRbB9WLflqZYRk3GrLllwBLn1Ag6iuKucvoyv7N23qXKIjqAhyKPmHx4l9w/v2c1pc3NB1af2xvtRWaQp19N98QouFFx5MwAI9+jR77Eox6QvRwA+L9CFkYlDTvT/aS3q+Zb1QH/8AE4QIDAQAB",
-        "desc": "Removes advertisements from Hebrew websites",
         "list_text_component": {
             "component_id": "kdakdkdknmkkafefhcbngpinlfoopoej",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA6OM0Ert1wGZ5bOxBO4Z8qikIwBWLZpXnL4Fy8zhu1NOfCODMHxv4WdEZLaQrSgpInAeHi7u0d0doNrBx96wwRJmm4Ng+HlP/dHtihNGWz1yAcrRoKzqQzwsb1Ty+4TPeKRcJEf1JJv7aveb4s3Z80Oo3C0UftdCDx/R7cXWkGqFB6I5CmtpcWWcLtLfb0sIKl3HE3rfDPclqK4sM46OOi7iGAlfk9RVcWsVv6on0yZHInT2T0QCWwvS2KnwuntARJ0jmIoQf8MrrfwwuchFrqyZ3+D0pZzg3NIXLSQSoVKySAOAafTE+NIQzElT9pVJPfFkJ/1kYRUGoIuc/OlnN8QIDAQAB"
-        }
+        },
+        "url": "https://raw.githubusercontent.com/easylist/EasyListHebrew/master/EasyListHebrew.txt",
+        "format": "Standard",
+        "support_url": "https://github.com/easylist/EasyListHebrew"
     },
     {
         "uuid": "AB1A661D-E946-4F29-B47F-CA3885F6A9F7",
-        "url": "https://easylist-downloads.adblockplus.org/easylistitaly.txt",
         "title": "EasyList Italy",
-        "format": "Standard",
+        "desc": "Removes advertisements from Italian websites",
         "langs": ["it"],
-        "support_url": "https://forums.lanik.us/viewforum.php?f=96",
         "component_id": "nkmllpnhpfieajahfpfmjneipnddhimi",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAurn1cJrIcCa8P7hjGex+OUHi19PRxmjJ5DuQlMAeIaKibwaQOZEPXSvD+O+xgxHZJs1o2DE8zfj6yrAmDfu9+/T0ArT2RWuopDMEfaKdeG0ylHP62WJC+KGUhCiTNmLyPxbU9AiwydVyFOam8vs4Tr+9I3lYKVeClQrtDRM34BTOAsuHRjiuIKoC0jDC2kc+BAsAbzhIdrkEDGD+qx0rCRnGL6c8xODe2PLKSkCSIsqOk44eYOkBqQd0SgmCvQjXS2XczMDNuV7DCZofErsy2iEv/2kzhkkN8GFwbRkYGN9LuK8rtekE34AvZKRHS6e/pHjUCYJb/2xv6elC+VLsJwIDAQAB",
-        "desc": "Removes advertisements from Italian websites",
         "list_text_component": {
             "component_id": "eaidcpcfnepdmmhbglgjhpjdfodkdcki",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA6srtCOWjPWh8AiCrnjcJd9iFwmhs+5VMfnfaQnK5PeK1//Hr0xlrS9S6Q7AHlE3O7fBFS9EkBGXAXPeqNpXAuE1wKkzmKkOWRT2mCWQcc07sbIUjyXaQL6UIJYTQREJEZzif+beXopscv/ALsJkbTcMWaCbqrTx7SHVlIdkf44B4VccYsp99vhDg5pzhMgDtq+f2ni3jzM0EmECyp9lJefqVEvg1FXNLI3Z0DxkYr1izYCbH3X9NNj+xs7OFz+5eXwus/Ikt9JRtYush7Kr50O7fD/ouvdB/gpCXsvqDW1F3x97ysRZwEQTgioLlVnMs4DN0T0TGoGULr7QkmpzigQIDAQAB"
-        }
+        },
+        "url": "https://easylist-downloads.adblockplus.org/easylistitaly.txt",
+        "format": "Standard",
+        "support_url": "https://forums.lanik.us/viewforum.php?f=96"
     },
     {
         "uuid": "A0E9F361-A01F-4C0E-A52D-2977A1AD4BFB",
-        "url": "https://raw.githubusercontent.com/gioxx/xfiles/master/filtri.txt",
         "title": "ABP X Files",
-        "format": "Standard",
+        "desc": "Removes additional advertisements from Italian websites, may break some websites",
         "langs": [],
-        "support_url": "https://xfiles.noads.it/",
         "component_id": "agfanagdjcijocanbeednbhclejcjlfo",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsorIQuFuMI5OaGYaYTu6+kZC4j3qPoWRoD7F9GS0IJC+VEk3XQ7UTsRXlrIxP9obmC7+pByP6hknBUzvKKS9I1v2voIqjUoydWOozbfoVoRhTLN3UiDnoDueXqXiv1MGLzY/ZcsxsxAlIiTcE7+/KdM6pJ72Mn/aLKU3escIJ5E5qOHJOFDLW9587JeWOzexaCOrtiZMclE0KWbUi7qB3Bz3auF6piSzoNGeI1NMwHSSAwhDOQ3UK09aqRKhyfBq6ugrrYyRAr3FWqmMBWkiTsr6SzrbQg3wcGbD+GDvoQmqVf8dH/WYG+srR6PyJdYH5mOQs6Yg+nu1gvwQ46Z74QIDAQAB",
-        "desc": "Removes additional advertisements from Italian websites, may break some websites",
         "list_text_component": {
             "component_id": "njbfmhgmihdjfgecgfhgknkinndnojgf",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA85EG3eFmZn/VmRqgmfOzcqGNbCUIsj2ZKu/GfKG1cYz6N1Qyadmmx1slJhc3wqaSav9U15SaktcELk9d2dSXEsQPStluf2Vrw6ClqgTUmcxkjtni8PY8KRLd6ZKw1mUO29NonN7B8qEUWAiObqPP6dg25vSAoj1NXgnkq7WlA/JMZx+rijviam2Ya0HdXoUIOeuzYhNQERjH2R/Va2EDT+LsPXSjW3qGxfBabQfMuFFhjyTIvK5vRMNwoxTV1q7Z0o/zdB9HtXZlEWpkEEBiWFZo6F+4tUBopsCSICbSqbwAoJemo1O0BvR2suf+yIxuwbWMv4y36AtFBbhT4tiCqwIDAQAB"
-        }
+        },
+        "url": "https://raw.githubusercontent.com/gioxx/xfiles/master/filtri.txt",
+        "format": "Standard",
+        "support_url": "https://xfiles.noads.it/"
     },
     {
         "uuid": "03F91310-9244-40FA-BCF6-DA31B832F34D",
-        "url": "https://filters.adtidy.org/ios/filters/7.txt",
         "title": "Adguard Japanese filters (日本用フィルタ)",
-        "format": "Standard",
+        "desc": "Removes advertisements from Japanese websites",
         "langs": ["ja", "jp"],
-        "support_url": "https://github.com/AdguardTeam/AdguardFilters",
         "component_id": "ghnjmapememheddlfgmklijahiofgkea",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsOoGwN4i751gHi1QmHMkFZCXFPseO/Q8qKOQViZI7p6THKqF1G3uHNxh8NjwKfsdcJLyZbnWx7BvDeyUw3K9hqWw4Iq6C0Ta1YEqEJFhcltV7J7aCMPJHdjZk5rpya9eXTWX1hfIYOvujPisKuwMNUmnlpaeWThihf4twu9BUn/X6+jcaqVaQ73q5TLS5vp13A9q2qSbEa79f/uUT8oKzN4S/GorQ6faS4bOl3iHuCT9abVXdy80WSut4bBERKgbc+0aJvi1dhpbCeM4DxVViM2ZccKvxSpyx4NvWj56dNKqFLvzoA4/Chz1udxifIXUHh0701s1Y4fLpY0wWP0uXQIDAQAB",
-        "desc": "Removes advertisements from Japanese websites",
         "list_text_component": {
             "component_id": "llgjaaddopeckcifdceaaadmemagkepi",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAquaOTeP8r+FbVSg04QHQYQGU3NxdQNsbC3+K7GtAB7p1YnrbxD3YEUKYI357Tasm7URCWTtRGXIkOIxUv4hLL8JNUNKdROaCruKPdpDNwTJshWzPfgKo/ZHTYyduUUP1w4o1CfqQRw7FpekOebbTsm62yAEPe+RXxHfyu2YQ+njCX7IPvI0or2I3i53HCWz+fxaTenpcEn38TlkwLUdlRR183v+e6kfjDvo5HgvNQJsFFC9MM++yd8KdZrDuombSyFIUTzuP43yixeMLBeZ8IbGGpC+en8CA9OgekVhsIYWRbnRGzZmspgZ2Bq/SOuIqf0fLMgwLmNbgD4h1SIbmKwIDAQAB"
-        }
+        },
+        "url": "https://filters.adtidy.org/ios/filters/7.txt",
+        "format": "Standard",
+        "support_url": "https://github.com/AdguardTeam/AdguardFilters"
     },
     {
         "uuid": "45B3ED40-C607-454F-A623-195FDD084637",
-        "url": "https://raw.githubusercontent.com/yous/YousList/master/youslist.txt",
         "title": "YousList",
-        "format": "Standard",
+        "desc": "Removes advertisements from Korean websites",
         "langs": ["ko"],
-        "support_url": "https://github.com/yous/YousList",
         "component_id": "djhjpnilfflibdflbkgapjfldapkjcgl",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAux80m8cYDEXwq+nMwmui6NCO9SFAdcGly5eq4uGEIQNB1R6Tr9JMqosHLZ4PnaUJqJwFfLWfmxzXj3q0DIpqqpdSq/jTYT/MvOldC+VQFO+NIjXhtysh4Z5F0BzlsQx/leMnV6yoyQjBX53n9cl3BvQK/EdbuQSDiNqX2TSVLm7hnr7Vf8m4XYRSCSJybY/1Tk3Cqgqywlkr+YN58L1/txXCQ9LJ5SxJ9I56TxqA1uT97hBmQikvnopuLh1SovDfjtCZwWwaGDD4ujW+Qaeh9dRrojS47iwG/Twu1xbb7ra8cn8BxdzsPjUSSurpPz/9sUooYOGJO44p7u77sxeTXQIDAQAB",
-        "desc": "Removes advertisements from Korean websites",
         "list_text_component": {
             "component_id": "gdlpebjigadbdpjpfpdbmogebilelnbh",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA32WAaxLDPB/tRWpUQmFYskJQWzqfKz+MdTQGrvHbvCE2lo8ssU5BW/61oIBENfU7NXslKICOMREIU9JA1/I/ew9bF4X1VExdqaLkzwVPmTOKwamv3VNnNXydQY0S0MwexZ6lL8Dm++/T/mmo3IDY3AMfUX51NrDmNqJk5HKsAVJMDqGh5XGuySsJk4iZOeJiqheiUB7JP7JXaWBxjh9wO1W4/wp5oxcIN9V8LSowLGzG5e5MTH4VHjWkipLd4zkwYnsEC0pK+08i0WwEUEdGVFtqKTBRt/vCpg23OqrOIRRiTZaa+tUAy1YbtNUanvr3ioreTuYwbCx04MOLss904wIDAQAB"
-        }
+        },
+        "url": "https://raw.githubusercontent.com/yous/YousList/master/youslist.txt",
+        "format": "Standard",
+        "support_url": "https://github.com/yous/YousList"
     },
     {
         "uuid": "51260D6E-28F8-4EEC-B76D-3046DADC27C9",
-        "url": "https://www.fanboy.co.nz/fanboy-korean.txt",
         "title": "Fanboy's Korean",
-        "format": "Standard",
+        "desc": "Removes additional advertisements from Korean websites, may break some websites",
         "langs": [],
-        "support_url": "https://forums.lanik.us/",
         "component_id": "oidcknjcjepjgfpammgdalpnjefekhge",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvCOljWKWLWfq/k/BE9gIZtI1MstmG+NcgGBGAP0R7xgaUMU5phdSbQf83Zt9ctwDRpisHWlGS6o+tk93zMIoJVj6RMQ2Zee6QPAKAGgwuCXF7A/ciI3lRyX7ts49XV8GAbasu1mBHntz+GpmOVmoiRxcDMUDDEqsSXgckCM9HkYvIyHQWyEgeulKdhQ2HoCptD2Wgmws6NzRTgQ94+DHu2o6J4MsG74h7L/cG3XB8WQNuqlpjjFIQTXftuUWDSkyR3tlmMxGN1PXAH6RZBNmwQTwdgrOAqEup82dWaO3BqoYGZdYeRaUGRc73iPdvvjZb1tvmqLdVSq7Ur1XJjJJTwIDAQAB",
-        "desc": "Removes additional advertisements from Korean websites, may break some websites",
         "list_text_component": {
             "component_id": "iihfaghdnbilkdhmmnnkebhodfgeaopd",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsS7LwpmM6baZKPgEVYsRiLZAV6TpvdwRGAoXbprVO05/uSySDPuRvmQt/76oODglOIF3ZJcru+YJE/nCVrXApHbNR8Y+LWsbKf33Ae+Ljw3GuzYOnnIpH6hsgJYGShCWya/5np3pzLpDJgYKdg8TFdnjmf5xQ7h30xek3qAHPzT0gUfa/GKlIiTo0yyMz0qT3evxlDOtJhRK/zC30qnzQuFqMmu0g58klp4XGZ1E1l1CaY7dY3iOSYZnjEcsK3ooKwpnUGi5JICJw7bUI4RxiDX5DL72SOqS4NZSlOvX8nkMZWW/iuYkYckQD3Ya/bCOZlDaZjKoQDHAyXE0zeP5hQIDAQAB"
-        }
+        },
+        "url": "https://www.fanboy.co.nz/fanboy-korean.txt",
+        "format": "Standard",
+        "support_url": "https://forums.lanik.us/"
     },
     {
         "uuid": "4E8B1A63-DEBE-4B8B-AD78-3811C632B353",
-        "url": "https://raw.githubusercontent.com/EasyList-Lithuania/easylist_lithuania/master/easylistlithuania.txt",
         "title": "Adblock Plus Lithuania",
-        "format": "Standard",
+        "desc": "Removes advertisements from Lithuanian websites",
         "langs": ["lt"],
-        "support_url": "https://github.com/EasyList-Lithuania/easylist_lithuania",
         "component_id": "dkbmlhggeoegbkimcafbfhjibdknflnj",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqCK9nqZcPjszbCmHXHMyLgwzSJGFHLIRKGF/QP4GRhdCh+gsiE4Y317mNx9Q0ogbrvsmYGzI7z+Vzfh0BSOEYVs3bl1dCNENPyf+f8kXWySoHY1/u8jMyeJsIPFrIhzjoypGYgqmjFTSnTAYhTPKv6fQ6KHUsNn/5WdKis1h/yPQSFWw7PX7wJubyD3UsE6mtWegpR9sv8mJdaFGvCnTvxm0NRxuAlP+3yINKmnTal82KpPTXh3o4ehNUsGQb8ibcMT0jFmq7VcD53gxojmta/AhBjP1LmByPkUMe8yCYKpnW3zMg1LS4JNcWiS8H2ApUUSW/9wUKMZI+3gidakP2QIDAQAB",
-        "desc": "Removes advertisements from Lithuanian websites",
         "list_text_component": {
             "component_id": "fmddkdeghohhfoglgdpkhlnfgmmffklg",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAlW+uDh7W9fxDMhekhHT+KeeAnf/I9SHZWNjpXeZ0bdhEqi8BxJ8UQFAABdKp0ZIg5mkurvx8/y3DYXrnM4z2Dd21UDmsweEVsS342RNZKtmxo9QFg/Zi50wwMcaVkGo7l3D/hPHb0Ss+M7y+E4bx9KkilUw786DPSvW1Z8jPKrx60+em/7QluU1LtkLjMXDocgG7bSvx9XV5thcCszXOGgoDVGlosD2gTVljXmtahVFUU2Hh42Iw24bQRc+PFYeqp8f08M7v7G0jmCWcehXWlnrr1wbmqCQvcLr33M9E7z3LisVoVOW+Nx6upsC8MgNDtbgHgub0ZAPm9WemZ2wfJwIDAQAB"
-        }
+        },
+        "url": "https://raw.githubusercontent.com/EasyList-Lithuania/easylist_lithuania/master/easylistlithuania.txt",
+        "format": "Standard",
+        "support_url": "https://github.com/EasyList-Lithuania/easylist_lithuania"
     },
     {
         "uuid": "15B64333-BAF9-4B77-ADC8-935433CD6F4C",
-        "url": "https://raw.githubusercontent.com/Latvian-List/adblock-latvian/master/lists/latvian-list.txt",
         "title": "Latvian List",
-        "format": "Standard",
+        "desc": "Removes advertisements from Latvian websites",
         "langs": ["lv"],
-        "support_url": "https://github.com/Latvian-List/adblock-latvian",
         "component_id": "hmabmnondepbfogenlfklniehjedmicd",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAst1posKDpKt3WLU07CziowQnBKYXzH2i/sDdJfMuTcKSNQvn9dxbHVLhg8Ih7NmN6SSJTRgb2PughdVNPXqlT3/jGioDC0gN8kBrBoN2YWgIW2wdvTCPvBOfwTOhGueQY6AtE7zD/3m9v6Wfcw07Rj84Su0qI1Zadmq2pBWo5z82vOAI2yV83YGDbnyK1JaFeLToYQmj+bMEojoZ4Lk4PbFmopVh1GkeOdCKtVN2NTIy43N/w0tS0wlLxjwTyZ6RIcK3VOhQXBqcpwKpKm/4WDksTvNRLZ8e526z/nqaasM/meS22hURh6NPtIOdy6/TspTzFPiRdj2xgNfQZ9oRxwIDAQAB",
-        "desc": "Removes advertisements from Latvian websites",
         "list_text_component": {
             "component_id": "hkeaopcnlcfbmbogejmbipnnopjlpiph",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzKJQ+ZqjJLJ6sBvIhxOmFV/jUJ2qIdEwTjvNd/zb5jmqiYhFTamZph1qoov3S7Ob6oFZIrluwhYP3i6koTOLFMRDpgV5m6K0xtAZyTxJn/YrEi0kqJ1DY+v9OOrtMOSZTF+Y5GkYsrG1F28KQm+pxJ9BVreGBx93Tis3CbGTGorPHbKe74IyYtWHEJ7azFhp7O7bLAMZfO3j/g7XRK4m+o2pW7pmd+YVdixQOblWK6ha6Ircowo8M/LwlQ1Z7EAmpXSUzEk4cGF6IlekyEou4SmcR+eNZcGpTc+KRNGe+gyZVkd8HuVlG4fphFQRGkNxl9/7ttZLohO5CGJQj5srVwIDAQAB"
-        }
+        },
+        "url": "https://raw.githubusercontent.com/Latvian-List/adblock-latvian/master/lists/latvian-list.txt",
+        "format": "Standard",
+        "support_url": "https://github.com/Latvian-List/adblock-latvian"
     },
     {
         "uuid": "9D644676-4784-4982-B94D-C9AB19098D2A",
-        "url": "https://easylist-downloads.adblockplus.org/easylistdutch.txt",
         "title": "EasyList Dutch",
-        "format": "Standard",
+        "desc": "Removes advertisements from Dutch websites",
         "langs": ["nl"],
-        "support_url": "https://forums.lanik.us/viewforum.php?f=100",
         "component_id": "fbmjnabmpmfnfknjmbegjmjigmelggmf",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqqfwmNS4XOq9pWC3XSMt5WcqoKaj3lRpYAwZKTP+6DwA9pG+Zw+0iWC95riSLjqPgX+0d2cZaqjinuNn3mUMOeGdbwSIeRLE50J5J/dMmkg5YO09orZKLBjMfJG5IDgfXdZLSJtmzKC4Xj2y6KSuQ7N0Sg5f1Ecc19nFbcFazCaIhKvcoA84J7Twf2IoCDuPMsGplgZCBtFQkKeqILaVhJZeD0my6pdC2KJREbM3eRnntE44O0sbmemCfHs9BV50hVb913zGDZ379eTqg3mPjvH+VnY+7RvjVPayJP4+51zRJYKi18W7KMry3sj4ZZ3EyNKmbwlGQOzAyd/Qtj4I3wIDAQAB",
-        "desc": "Removes advertisements from Dutch websites",
         "list_text_component": {
             "component_id": "oojedkppeblkjkcdlmlahnhndjmbicoi",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA258rAhhideU4koO8wXSn+mgxg+PBAv3+4fYEgf8ezDIOb0zXikwunPGMUCX1Z7dpyqhzYjtYFZvdPlXWJglEA4mpRpQjb5MUKALRC5oQopDhQnZlwhL5YtPYEo60yisqAEFrBm+ngdchqI/41AZuAqY0eNu6in5wxoW2norZigFMovXDWGSEOt63cpXg9KjcwN02cH26k2DO2jLLUFkjRCy6v1XKFufBMoGc6T1MB5wzonFeh1uZvJHJV/M6P+NZuRG4F6SimF365Uq11bvgLzE49tIWVXdkt5MxPzJESr/+r6M+AfGK5nt5tyWDRAW5Wrp74ae2T7p3e0grkqNeuwIDAQAB"
-        }
+        },
+        "url": "https://easylist-downloads.adblockplus.org/easylistdutch.txt",
+        "format": "Standard",
+        "support_url": "https://forums.lanik.us/viewforum.php?f=100"
     },
     {
         "uuid": "8BEDBAA8-4FE2-4FEA-82F2-81B8124A4A74",
-        "url": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/NorwegianList.txt",
         "title": "Dandelion Sprout's Nordic Filters",
-        "format": "Standard",
+        "desc": "Removes advertisements from Norwegian, Danish and Icelandic websites",
         "langs": ["nb", "nn", "no", "da", "is"],
-        "support_url": "https://github.com/DandelionSprout/adfilt/issues",
         "component_id": "kcffflkhcncgnbmgdhcgjfogpoacfied",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAocZlfkzlHWHXKsez5tmC4fFn4sJcjP67IlACrJIla8GgWQ6ipDCntH6Qq9zACQeePL5jocESzqh9vzdFdgY66puCk8dnLz3VOciDMLABwwf76runOrWVEEBUyDK+tq07tdHRz7V7QohRuvRoqRvdnXdbi/mcZGApuF+UjXVhs7OVGZSVsS9nriFkm1RF6BAv4/9wB0XhfCODaX/5bI34V1TbteN6d2iBKrDD7e7RxJCFBz9uCmHjR+yrxyZFBxDkgcH9FrXm+7tOGXuLmJljZ6frazp2Eg75aDLkC1O3FQgYqUP5H0Kdyexi6HmizYpQ4hW1Zhlv2hqeArAs42s1XwIDAQAB",
-        "desc": "Removes advertisements from Norwegian, Danish and Icelandic websites",
         "list_text_component": {
             "component_id": "kjdbffhfijkonelaglifggkchhmgmeli",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAr4vfQONxziLBVdFe1dHEjn5Ut+TcO62xyF0yfF9MVZqnOq00SNzyhUbXyzU6HxSzLU/eMkmTeIBJ3h+f4f3TPirs6s+EtqJkZ8R4er5aHhexGLKUt3uhkLv1IYYw9JimsfxMQOKWtz1O2MmbJJ5HcQ1jQQ613x6SOWtPpkeH0FdcwSiV83DJMVUjVFNwBdl2zjqulQP1M6geNt6eSNN++p2oB+K5kfpMAPopRuRfhZ1spDSm65qfBGGYfgPl6FanfFpTMm/U/vC76KeoMW/xpQw3s1TQeQDY3QywBWasUxmxiJN0DRsVapCAFqT0dXQ+Q3GCCCGPSB1+EUusnSJpgQIDAQAB"
-        }
+        },
+        "url": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/NorwegianList.txt",
+        "format": "Standard",
+        "support_url": "https://github.com/DandelionSprout/adfilt/issues"
     },
     {
         "uuid": "BF9234EB-4CB7-4CED-9FCB-F1FD31B0666C",
-        "url": "https://raw.githubusercontent.com/MajkiIT/polish-ads-filter/master/polish-adblock-filters/adblock.txt",
         "title": "Oficjalne Polskie Filtry do AdBlocka, uBlocka Origin i AdGuarda",
-        "format": "Standard",
+        "desc": "Removes advertisements from Polish websites",
         "langs": ["pl"],
-        "support_url": "https://github.com/MajkiIT/polish-ads-filter/issues",
         "component_id": "paoecjnjjbclkgbempaeemcbeldldlbo",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsUqWP6CeMx79UyZ3GZ1XcBGexIgml00sB286wZ7dJsfqG7oI0EGRoqrDeRreYcOTl+HvXsRJvR1FfkKJzD5svdhR4mn4lI+FXUDCvgEZ9CFa0YfASuoTIrdZtG74Twu2ai52ZJzrQ9ike97bdwzuZo+uymw26S+5/+IQbriIYoxEbJd7EryZuo+W65LdSat/NOKKf1QnVTIOoqMrXiewRYywnmZATfDIi0uKXuQfF15lbNBkQllmPH1xlMkz2WnvSvqI4HKPAmEFJWVUkiNhGKFZkTk1+88CgGGPVsKllxLaDOD+j8Kb0+h44RxObHTF/vFkfh8FfzujFj3HtevjCQIDAQAB",
-        "desc": "Removes advertisements from Polish websites",
         "list_text_component": {
             "component_id": "ngcohbdfildjnmfnicgdipopmlhdcokg",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzI7s+FWv8M/Nr+OdXIooICxtv+Q1TS/gpN32+ToVeFHuaQwWZ+O+aN95D9ZRrRb1/mQQW6EkY9Ce5LxUjosw0C9bF0yyB5AEZ+lJQIelrY2c9AvEK8wcNiI/T0GTEcpB0KnOI0tMhfVZZnUj3piiqUZHvXKvcuA6bPoaalPy260o7npU53UZjtMf8RGEigECWqaEMLqYRq4j7xhX8Y8lMeqGfw9Ff3jC2LUSZamTHL2lSdCzrlYN4LMHnAIawR3HSll295BEwo+OBj5vjD4JpZ7NxapUPnXw8k/CGfsKPomQwuBb/JWEGBsgaw+5EFPVKz69MoqR90p6hdZptQZJYQIDAQAB"
-        }
+        },
+        "url": "https://raw.githubusercontent.com/MajkiIT/polish-ads-filter/master/polish-adblock-filters/adblock.txt",
+        "format": "Standard",
+        "support_url": "https://github.com/MajkiIT/polish-ads-filter/issues"
     },
     {
         "uuid": "867EF333-8336-455C-9CC6-98749AEE69E4",
-        "url": "https://raw.githubusercontent.com/olegwukr/polish-privacy-filters/master/anti-adblock.txt",
         "title": "Oficjalne Polskie Filtry Przeciwko Alertom o Adblocku",
-        "format": "Standard",
+        "desc": "Defuses anti-adblock from Polish websites",
         "langs": ["pl"],
-        "support_url": "https://github.com/olegwukr/polish-privacy-filters/issues",
         "component_id": "baophminpaegfihdcekehejfhpmjimle",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApX6GHwd6ZsPNk4iomzHF6fb69FJcVyRNTQc3X/LlDuEXERJ/eZzDVMn2pCm2CTCXQHweQWqBkC/20FkjniwGb9LSjzP5jdcDCFmSwaFWdiM7xG+BfMFP+XDJtjOlqirWESi6dzwnQ5pKQDpNCblMBuuhT1WyDLtHODwbNJs/jILdSAapW8eQApQ/iCGidYPbPvPL53bq+u45UXXljillsJTbGV8vu2VVhf9/fL5McKu7uX6xR2i4WR2x1hQYMYu5rnFIrDNWGIn4CNDodO22nyBBjznGfQ8XVp558s5tC+v+12hY6HJW4CWJ3Oes+PXuLPDUwYuJKkuncfADk49oVQIDAQAB",
-        "desc": "Defuses anti-adblock from Polish websites",
         "list_text_component": {
             "component_id": "beeceepafhbchnbfdkfalfipoancnjkm",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuvdYUaLF2iI9loRQjDLZelATqaMso9wPX0sBZR1i9MrqM5pw3o5x9sc57SYiuCQJMKwD8l8g4S7WEHyfGs43EYmiO0/1LE2QJ7765x3tyN4LrH+PIGvrVdFkdeVv23uQ1Vk9kZ9OiCo5+ZvpGIavWFGQ7Cq+QJAu3omKLzHQUpfph8UgRlEGjJo0g07Dc/4vsNE8qF9LRTpThxlMZIvWU4ZPsd/bW4VBipvAMDyMvUBwA1gW/3ehPY4rekuykK7RGcsX9hCoLn0Nm3J9/tHfYk0vS76yNcaYq1saITBlBzqPnrwAc73sQjpMkwfWgdrPl0JsQJ9lRlzeoecyOcmkEQIDAQAB"
-        }
+        },
+        "url": "https://raw.githubusercontent.com/olegwukr/polish-privacy-filters/master/anti-adblock.txt",
+        "format": "Standard",
+        "support_url": "https://github.com/olegwukr/polish-privacy-filters/issues"
     },
     {
         "uuid": "CB3A9B4A-C9F3-40FA-A6B8-5219ED5FA9ED",
-        "url": "https://raw.githubusercontent.com/olegwukr/polish-privacy-filters/master/anti-adblock-suplement.txt",
         "title": "Oficjalne Polskie Filtry Przeciwko Alertom o Adblocku - Uzupełnienie",
-        "format": "Standard",
+        "desc": "Defuses anti-adblock from Polish websites",
         "langs": ["pl"],
-        "support_url": "https://github.com/olegwukr/polish-privacy-filters/issues",
         "component_id": "ndgeclhidhlfgmjdcapejaldbahmkgbi",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvZaLRYXrVyL6jjJF8guXpjmUFv3nJd8hfLmbldBIiJ21bMPpaypGBjQANxIU1Sfz1jpy9J+OkB1ifoDg0ScWqDCD0zpjjS87g9ANGantkh55Y+TYDe7yGq6JF2ELr618y3UJTSyfMUi2jLlmved/1Zmtuup2+nWS3Od6NfnXmV+pHJXJLTX7n397RVb1RNN8U5WIvx6vnpZPVB2H8YoNJd9JMj2olIm6yt4Y0ODMOOAXuROz02QLBwnlZC39Z+BuNVxW2fqhLqFw28MD308v2uYiY/Vc0enna8UISSvebYwJedwZFCzk1CVWaO0Y6vHOBVtH4DwHb5sVxUzx/KI3dwIDAQAB",
-        "desc": "Defuses anti-adblock from Polish websites",
         "list_text_component": {
             "component_id": "bdnfonbomiianhopbpfgfeekmlcbegfo",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA77Cpl7pDmqWRY8sjZhvJ+GxIHDmA7PvUZinQz0PoOz3wEuWmuFU6mOOx6uUi83onGMamcu5ofHWAZBNYRIXbbPcpC4a87YLbpfTegKi7TX9BTFrUMUZCKlO74z6LZO8R1APLAcse6rubCkpyyuvMZ4mcbCA+vKv8RPh4YLhSRWhIi/UvueiaTOew4QkAq2W2q1FtStK9w5uBtBJBFX8LR456AMKZ554bpZ9jea9/8kasXvrbujwyx6G1KueQW1QIUlXbVVxGs+fKMMj3UYxIODYQUqXkV1YvWmdZ3jNApnnOyeJJNEAfNlMw/KMJM2m+S9apXqOdR7VhE5SCZ99wlQIDAQAB"
-        }
+        },
+        "url": "https://raw.githubusercontent.com/olegwukr/polish-privacy-filters/master/anti-adblock-suplement.txt",
+        "format": "Standard",
+        "support_url": "https://github.com/olegwukr/polish-privacy-filters/issues"
     },
     {
         "uuid": "AD3E8454-F376-11E8-8EB2-F2801F1B9FD1",
-        "url": "https://raw.githubusercontent.com/tcptomato/ROad-Block/master/road-block-filters-light.txt",
         "title": "Romanian Ad (ROad) Block List Light",
-        "format": "Standard",
+        "desc": "Removes advertisements from Romanian websites",
         "langs": ["ro"],
-        "support_url": "https://github.com/tcptomato/ROad-Block",
         "component_id": "hojdjlebfkngledgkgecohjkjjojaekd",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnhLXi2u795hnBUJi/vS8qtMGoTYk9NRefWk+SI6fkqVdiKs/eM6Y8v3To4HgNmtYb4jAoYctcq3/CS3hzGCLEwQbDuL8Y8UP5B6PWgzuiRrAobRl1DtXO1+Q57VIrYTpJVLCqaTulclys7Fka/wD5o78Y0vAfSenBZTzRUXwTZd9Z7SRNwcJyccbi7zL8UDWnJMBnD/dnV7t2q41MHiCgdzimOSuoRZmTBrupVc0QYhqoxy6ePkHFDGL2U25omAZckkzpQbtvJEE2lmg7YqnaSvGDzsmqd+j7hVWjpm/ncArLOWBCbER3MdHwFeOI2rFJWcO7GY5etQsA5128FAv0wIDAQAB",
-        "desc": "Removes advertisements from Romanian websites",
         "list_text_component": {
             "component_id": "cgmhmpbimmakidhlkcnnehhicoclofep",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsPK8KQaEM2wDchLR8GfV40qmWdwi2QPpKhBq62Tihw7gmFjKNIQN26fHB+NDn8H/GC5XCmZD2uAMrRvcfR043imLWnCmBU5cHtPoQNAN/VWeffzOMaNn5JIMlpwtFZDfISXAaDiNMPLY1uEEVuVwqoX4bA/U6VfCnkIQcQwGJO58AH50Dk0Deq2xgUWmFpJgCMwGcp0Hv1OEERcVhtmpoaetVtfkUmBsOd0CwcSdT4p9zMXWRuHGmgbMayBXL63hksmnNUBYcyzUqxSDwA4OqaLaNZovLc3CMgVXQ55n3wpo+HmMDhr4OLWULgXsZDne5wehZS6QOaR0G+bqOmev7QIDAQAB"
-        }
+        },
+        "url": "https://raw.githubusercontent.com/tcptomato/ROad-Block/master/road-block-filters-light.txt",
+        "format": "Standard",
+        "support_url": "https://github.com/tcptomato/ROad-Block"
     },
     {
         "uuid": "80470EEC-970F-4F2C-BF6B-4810520C72E6",
-        "url": "https://easylist-downloads.adblockplus.org/advblock.txt",
         "title": "RU AdList (Дополнительная региональная подписка)",
-        "format": "Standard",
+        "desc": "Removes advertisements from Russian websites",
         "langs": ["ru", "uk", "be"],
-        "support_url": "https://forums.lanik.us/viewforum.php?f=102",
         "component_id": "enkheaiicpeffbfgjiklngbpkilnbkoi",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArVVgKRE868yup0HfX4+HyZmJVIk33AKivwvRRfjHRxeC+lLnRjNiY0LKS/K65J6SNLgUsZGfT5u4h4F423O/pbZl6zdfs5kOyStlmLPXhFtF/bIXIsUtdJ0R3dEz+nSg0C2L/FnE5Qr8M4thdmq/DIP1C70mj8pCnX1939hXyR0ymQkYp573O+LJ0q1L41jBqHzNKWngfBc79I2Kbt1pLluBT2X7zZVbb+1ap3Ad/VMeFDB2yurRs88cYJZOal7mgTgI/Zkuzsh2Dnql5+UNOCHinYjcOvUifGgkdsJIJxL57PxRzbriLCNjShoOV3Fpc0XYL1KSWvIVuW0bYeLmrwIDAQAB",
-        "desc": "Removes advertisements from Russian websites",
         "list_text_component": {
             "component_id": "phmomndefejccjmpiehbogokakkmnmgb",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtUdVZS1RGK6o+gfhEu1d8o061nYg/QCvHhojbyt09I3H+sc3lIr1cpK37msXq+DaFQ1LHbNk+9wTDfe7IIpvMFGSWx27P0T0mh63qjuFzfP5dSIDWhlCgPl8bUbHkf3e1bbNC1TAlGQDjZdxz7t/qDfslICWXLcKVz/1BtT/kG1PPrXjRq+NKBEqqV841RAIXnH4/LcfNLVCTs6EFvqRva4aN1DHuZdejLAMAbgR6JH0cMJ9RBO/5/ebZUL6C0XFjobgdj/2Rh+GYSrxL3jDql7jheKOrTbpJx81z3iUNwghrlHD56BbFs0eC3ZOAYHbIdYBkFIUPwpL78v5xyA94QIDAQAB"
-        }
+        },
+        "url": "https://easylist-downloads.adblockplus.org/advblock.txt",
+        "format": "Standard",
+        "support_url": "https://forums.lanik.us/viewforum.php?f=102"
     },
     {
         "uuid": "1088D292-2369-4D40-9BDF-C7DC03C05966",
-        "url": "https://adguard.com/en/filter-rules.html?id=1",
         "title": "Adguard Russian Filter",
-        "format": "Standard",
+        "desc": "Removes additional advertisements from Russian websites, may break some websites",
         "langs": [],
-        "support_url": "https://forum.adguard.com/forumdisplay.php?69-%D0%A4%D0%B8%D0%BB%D1%8C%D1%82%D1%80%D1%8B-Adguard",
         "component_id": "dmoefgliihlcfplldbllllbofegmojne",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4p+4n2wNFQCqQBBJDsvs+oqNYGzX3cbpY7fKbCjrRVE5esJK5HZJDoUUg43pPvKrCOIQ+lF+dXpBaCNnO4O/7JeFt2IFRJnKhE3ipIBAAbFymfo5T2uWFdyh6HcK0FNyJ/7FyHnANe7vYhXJS1Fqmh6jTYkAEIbrbmxtzrDMefx3XJcVhUV3XAPlP+K3MerxudIH++4fn3X0vKob5oQQQ9ZZ1PVcW6ZdZTQwQWtaVDb6prT+ULaphRRmnZpZuRXyHMv9KC8YP3K5ou+/Yd3uxxMwKmJXD67ZoNMtS/Dtr0btQsLxiEgox5Swd4iqyLM/SMxr3LqgUIlNwn7KRbMnZwIDAQAB",
-        "desc": "Removes additional advertisements from Russian websites, may break some websites",
         "list_text_component": {
             "component_id": "jiajbjlakknofnkmlokcbanjbajpbdkl",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvmC+nOMvt+lDivZj50XLbNPrcye4W7en/zP+CqvSVZ+MLwcH6oOF/YtLqzVMl05JOAutllDiO0Kwme8E/EpJI5Tw/JIYTLSzm2t3hDbWMo7EB8WobkIp9vXIKjEsRaw/QQR0b6BoqclyunfCutQfM+dADwJStJypwQkUuZPV0Xgl8M9uPDO4srAcrAs5Afc4wIDRxgGL+yWlp/XE0eUrJk37pZY9invINbTlFUoN1g2C3fWaRZ+kuH7AtlHhucKLTHtQIYD/eh3bmq2+0eLcgC6dP87PhSADTujuUIHMG4QivBz8a9o4lmcvZLztjsf5eQDh8+D4En69/IMrpKM9mQIDAQAB"
-        }
+        },
+        "url": "https://adguard.com/en/filter-rules.html?id=1",
+        "format": "Standard",
+        "support_url": "https://forum.adguard.com/forumdisplay.php?69-%D0%A4%D0%B8%D0%BB%D1%8C%D1%82%D1%80%D1%8B-Adguard"
     },
     {
         "uuid": "DABC6490-70E5-46DD-8BE2-358FB9A37C85",
-        "url": "https://easylist-downloads.adblockplus.org/bitblock.txt",
         "title": "BitBlock List (Дополнительная подписка фильтров)",
-        "format": "Standard",
+        "desc": "Removes additional advertisements from Russian websites, may break some websites",
         "langs": [],
-        "support_url": "https://forums.lanik.us/viewforum.php?f=102",
         "component_id": "fmcofgdkijoanfaodpdfjipdgnjbiolk",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApGBuuxC9pqx2s5hUd3K8zeFUtMFt9X+rSKR3elqWztjIQrbOdXSeezHvhAUdzgc+Wv79ZoRf4i4amYs3Mg3wg783BAqLvlu9r6FsUAbcgVQtt+MT3Z4ZepwvzWU0NjUd1q4O2pNEUsE8SPjmOeb3KHOF5WX7CA1uIHT5xGQsU5Uh3VTZC8FIOGjCskDAAnJGUeOowlMBGL2UvlNQLiqzPSvI9byjwxIMN5OfCmxXXr4R9m88oVK2D1gj7vfwBVJcRdV8ner4ZSuT68ncSyaQRtgI3/QyHc0J6giCRFmF0bHN/5kjFIWrHg5+uiBQN4Qt39TVCUU024Fi2RGInvTTdQIDAQAB",
-        "desc": "Removes additional advertisements from Russian websites, may break some websites",
         "list_text_component": {
             "component_id": "iiglahilpgmhlcogkkihklnbcjjgpddl",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAypc9kkULwkl0+NmhXX7MZNsoF/G3QaMJ/sYa468w7rhQzJ8PMkfeGeYtMQnvpLh3pALw4Y0gAlTwWaK21BZWdrsAyjk4IM+gTsztSrK7ffflw4usQSlOI0MJpJ1lj9pKCSeux0Pr0P+mGFWMDIxDyefBbUkMzM1JmsVXsDHVpoHikepAKkBKwW0F8Uzv0jFa1M5BxRK5n9nLOxTA3gCmcxUjeLMAYtQvzGf5pg/YwHz64J+snbwEJo8Lo9dUcpLk9ZoNuMqgoVa7UV4FgXCYhT3c3/cyK6673gy33WW5I+0tu9qTpY263StQ1hUWx2LnylJ4qbI8kKqotiGJy2JoLwIDAQAB"
-        }
+        },
+        "url": "https://easylist-downloads.adblockplus.org/bitblock.txt",
+        "format": "Standard",
+        "support_url": "https://forums.lanik.us/viewforum.php?f=102"
     },
     {
         "uuid": "AE657374-1851-4DC4-892B-9212B13B15A7",
-        "url": "https://easylist-downloads.adblockplus.org/easylistspanish.txt",
         "title": "EasyList Spanish",
-        "format": "Standard",
+        "desc": "Removes advertisements from Spanish websites",
         "langs": ["es"],
-        "support_url": "https://forums.lanik.us/viewforum.php?f=103",
         "component_id": "pdecoifadfkklajdlmndjpkhabpklldh",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2eGyWcTM6Cpmkw6CBBxQbJCgp3Q4jyh+JR/Aqq5G+OFzxFpwlqW0dH9kNuUs30iSt1tt1gMZGYnhPKiGhtX3nV1iYg2K8k82wNqA5+ODfHxnnVn536UoC7rmjXL+mhpymxgkjGCQ+1HVmnCcSC9mxTPy65ihor+YZcRRPo0IhjQTx3NgdpzkGYvpQVjwnw3a5FpRBCbbp3X2x3EGV3DcjvT6DvvxSU/mAUPlXISo9OFHYUpADilqAevXQIs49LSmefSDu4pezGyR/JoRLh7QR4N3fC17V2E0GazWxvn2U985hPE3tvFcH+LM3EypVRCl6E9AiUZCeumqMBffyXw1AwIDAQAB",
-        "desc": "Removes advertisements from Spanish websites",
         "list_text_component": {
             "component_id": "fejmaeodjeekfldnbegjagemjgnmhfof",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAv7yIqlQQ/fK5DkO90mULt6tdYXm4sdROKgLMd9PGxuXkTMWt2gI2VgnOIMKXenr6yQ35kx859rr7dcV8bOUPPCVZsu3zU3mxJoPt6+wOZH00na1n6XVS/jHFULOeqKA7fj/2GYyTvdaSpLL2B7u/limqbZ/IQSBoc0GdEfsjEghKFvFhWmZw6g0UAp0ZiJzm13t+ta2FjCDTfrnXJFt1VY/hd4Ip2i4KmBKByR0gfv4ksqY0rSVJhXjcbrXHqBZvRUr/vw6bBmnFVCJlQKS44S/5QLDsmxm2E2kIp2LmSMLjoYPqTZnthCX9/svwCp08LRwvDHtVSS3c5MsgRzwMkwIDAQAB"
-        }
+        },
+        "url": "https://easylist-downloads.adblockplus.org/easylistspanish.txt",
+        "format": "Standard",
+        "support_url": "https://forums.lanik.us/viewforum.php?f=103"
     },
     {
         "uuid": "1FEAF960-F377-11E8-8EB2-F2801F1B9FD1",
-        "url": "https://filters.adtidy.org/extension/ublock/filters/9.txt",
         "title": "Adguard Spanish/Portuguese",
-        "format": "Standard",
+        "desc": "Removes advertisements from Spanish and Portuguese websites",
         "langs": ["es", "pt"],
-        "support_url": "https://github.com/AdguardTeam/AdguardFilters#adguard-filters",
         "component_id": "jpolmkeojnkicccihhepfbkhcbicimpa",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAs1E/bf3s1EQeJY10IT5/ZMCzfMAm6SKyWUCeHBkWZLcfwyYLJww84EC2jCLeYgwukOmZjwtnDrasVhUyKOif7dKIBEZizsvSldi8tzHqTbX3PFKsLhRXCETbU0kkOlArGRGLaBIhgT07qPtlehYCZoDdowk42025fVtfVEMtZg8yBIqtFT/bDL96lRDQIW+1uAM3uFkzvRtQgsYhoI6JlyqFw6fqowRx8a+zHvtQzAUyIaTGf0OFEHwGCFlHXmTYpcOXlcUAXn4RnJvx+thpeDBtAvT6LubTLNQClBbwjGL5d7NlGNPByYdcZZcvGPmBWX/vnobY5QGP4lWxZvWfFwIDAQAB",
-        "desc": "Removes advertisements from Spanish and Portuguese websites",
         "list_text_component": {
             "component_id": "meimhmgfbckapkbbbdaoefgnbppmkodp",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvZOGZijGxkLbvTxJY/4nih6wdCBI7zJLrUwOUMXsv9DOVRJvh8s5CHYRQDwxUhNbWGOubxyjYT8Je2sb/5fLFJXqBFbC+xZQbRAshfpOJjO+ZJC6EAUz+MsG/xWqQZfHHuJ71yLSaSt55dFSvZiF7XqIPIrT3enTdILCgT6Ql42faE6d3EBcQm/lR1fyuBS8PGfcjiIL6rIvcNiTSvU2530m/x8ie2rWijMxJp+JlHejMzc3OJ3Z7Lz+52u/WFWMeTbVNDK4LQ1OEwTPxsARd13UTkk9S0Kf4B6G3OdND3lpzso3CPF3z52i22SUqOJE4nudWKWqkXVoDVNJGebnCwIDAQAB"
-        }
+        },
+        "url": "https://filters.adtidy.org/extension/ublock/filters/9.txt",
+        "format": "Standard",
+        "support_url": "https://github.com/AdguardTeam/AdguardFilters#adguard-filters"
     },
     {
         "uuid": "418D293D-72A8-4A28-8718-A1EE40A45AAF",
-        "url": "https://raw.githubusercontent.com/betterwebleon/slovenian-list/master/filters.txt",
         "title": "Slovenian List",
-        "format": "Standard",
+        "desc": "Removes advertisements from Slovenian websites",
         "langs": ["sl"],
-        "support_url": "https://github.com/betterwebleon/slovenian-list",
         "component_id": "lddghfaofadfpaajgncgkbjhalgohfkd",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4cRSF2Rg5SSG6mwE6NQCnX4a0MfzC9URqNFnI4Wf3d3a7CkhmVeNZHxSCGGLxNV9SjCi5tko7NdMqIwnN/vliZV+jnEDi8Lj+zz9nftkaGXe3jNoP7tr/+Qkqphc76j3wIpsQx/vBnfVTn5lrNynZL6qpFzX5dj4ukdJ6BOx1YTNdJV9LOyMWbC5rno1mpd14aS7R2T6xfnm3+nupaZMAbUeN/1bwxDdND/mbjFzFvkPCC+4m758tI/5kSJOefy8kNvp9BM64LXPA4sF59ttJtCIOJDAyhM1P0Danyze2g/0GGnojDuzZilfeSCeEpDsc+S78Tyqz/lMtxt2LZkvoQIDAQAB",
-        "desc": "Removes advertisements from Slovenian websites",
         "list_text_component": {
             "component_id": "nnpbcdahaefknppiijdmnckpdgojejck",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArD9/YNDpxamPQ937PVUqokLSeHB7pZCsRR46lEwLgD9FEQfNFd8Ji0K3irclaF6B0/3H8dvJbp3hjCOfGONWKmM7GpihipzBYEtdd1ueXDhnSoxNV/T87/x+RzaiTM2oznaAp+7jw+TfMkDyKYh3cFQMROTxTcE3rs4Ocs/mhBsFbumU42GRpQUSLB9f4L4KhLo6SGby2FYSSHspo46m6xJ63sGnQPLyiuH4hOF00b/XEQUUH6MYCg2WL51LZuVgFkcHWSBK/8HihZOn2ndAr2e2MEtqH7tmQMwQmVqouX4WITlbJ0XnrNUs0o8IYbOUmtp0SWTJtPHpYDeot5DXAwIDAQAB"
-        }
+        },
+        "url": "https://raw.githubusercontent.com/betterwebleon/slovenian-list/master/filters.txt",
+        "format": "Standard",
+        "support_url": "https://github.com/betterwebleon/slovenian-list"
     },
     {
         "uuid": "7DC2AC80-5BBC-49B8-B473-A31A1145CAC1",
-        "url": "https://raw.githubusercontent.com/lassekongo83/Frellwits-filter-lists/master/Frellwits-Swedish-Filter.txt",
         "title": "Frellwit's Filter List",
-        "format": "Standard",
+        "desc": "Removes advertisements from Swedish websites",
         "langs": ["sv"],
-        "support_url": "https://github.com/lassekongo83/Frellwits-filter-lists",
         "component_id": "oimfmeehpinnecjghphifehbbnddjkmf",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA17Vf1qj8dWwYVtGpBHWc9gLiITU1XrTnb1sDASIeuKYp9JNBtEnBwy4oBlOoZd2uWFKxXrRtaimdwqa627gi9DB17t/RgzisXSpLubXbVVelRWllaX26SioGxsGcQhS2/e1Bc0inQ8GODM6mk5FPZ9RObFN1N/QVz35anN4VNcjtETD/XpujYXE1BU3C0KGBlWwc+cQZ6sGojWEPrb7aRXSTJ5y/ugwGomTTpbT+Jt9nFrMfuAmJHvWS0Ev96dDmn1zsuoPGUExVFjGBunphRYMVCg9LUGzY0FN5+dp6fljrTJrtUOEfvh40vmjahKd0w6bKpgTAOUEaWulmVSr37QIDAQAB",
-        "desc": "Removes advertisements from Swedish websites",
         "list_text_component": {
             "component_id": "ggjlfgjhaeedkajcdpomeidjlniafdnp",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtMkbz7fkdzW7Gh+/F9yhFSSNRpWYe1FRYEkVPxClGGL7yta9cwmskmDqskAHaIP5JRQuvgJ71cSUgBWtUmDyhB4Cl5ZE6VSpe88xJxcrOctpwewwqbpwZB2/8PMkQFPXkjLoc1VvYXHRdjXVZumQq0wq3xnWNcp+o7WHebgciZIEBaXWyvg7Ire156qx0ru4AnxAkccKrv/iHCaKy7dcaEj7Npw85/s0zhLIK4jfwdYRe3/U1Tpilgq6R6JQ1rsN0eCi7aGuam9p7v5JZH8823NZ97jkURAJDJTfvY7U8auca1pSiBSzPBIrfkNXN6D0lRcLdO6Bm6cs52JbxYo4MwIDAQAB"
-        }
+        },
+        "url": "https://raw.githubusercontent.com/lassekongo83/Frellwits-filter-lists/master/Frellwits-Swedish-Filter.txt",
+        "format": "Standard",
+        "support_url": "https://github.com/lassekongo83/Frellwits-filter-lists"
     },
     {
         "uuid": "658F092A-F377-11E8-8EB2-F2801F1B9FD1",
-        "url": "https://raw.githubusercontent.com/easylist-thailand/easylist-thailand/master/subscription/easylist-thailand.txt",
         "title": "EasyList Thailand",
-        "format": "Standard",
+        "desc": "Removes advertisements from Thai websites",
         "langs": ["th"],
-        "support_url": "https://github.com/easylist-thailand/easylist-thailand",
         "component_id": "jplgiejfnpolnfnigblbfeeidoimingd",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAy4EQ0IdWDAAqRT6ymtxWG32Whfmv5TMxKuEP3rs9LMfa+iU+xiyE/XvWjgA58n4Bs2vQgefCoqY+a9B0TUkqz0nDcrBi371w1EZSxNRySslO5VvLHdRdYwynTMwDsAlHIPZ6pgh9zwprW1Lxz31CC2EHJeBGmBQ/S8My/VRiN8Y2Jj7yZDX1rTvBrYPj5XAwe2MAPAsMJD4lHcx7uClEbVq/4AxNpmNay5kamFaX6qt8/765RyPYuqgneharP7EJ9HToH56l/KR7doOywTyVPQYvEhD+a1mioMfEtYNxvqY4lKDhctTV8aU7RItAgwGTW+msldvdPfs3QWV5o7yrtQIDAQAB",
-        "desc": "Removes advertisements from Thai websites",
         "list_text_component": {
             "component_id": "johkmlmpfakcaopiapbmcocgpkabdmed",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA5ndE+g/8K+nvdkIEct4mtVFQpexmeklQqtbBstIw2hI5aF+HAvgtMk5RTn0qicwGku1kCJEn0TDP8IbAMhgcODc3BzCmPwnE/oHJ9EvO56+doo8SL5SJaQ1ws2Os1lOZeatnKWr07SaCL39M/Ychvj3yccDVer7T339XmZ/TvkaKMlrKoFYGJzoGPjoBS7vw2SvsFWHCgsVEtpbGEXZD029z1YaNDGPBPvnuk30Ir9sPw4uurqTZxR9RKquJB/QBm3l/eT3UICED30yFthpP+8DVLpH6J5lKM9EqD8df4VyiSjotYAqNNJKgTNWOzQeFud/t26sQgyXGVUBBT2VNEwIDAQAB"
-        }
+        },
+        "url": "https://raw.githubusercontent.com/easylist-thailand/easylist-thailand/master/subscription/easylist-thailand.txt",
+        "format": "Standard",
+        "support_url": "https://github.com/easylist-thailand/easylist-thailand"
     },
     {
         "uuid": "1BE19EFD-9191-4560-878E-30ECA72B5B3C",
-        "url": "https://filters.adtidy.org/extension/ublock/filters/13.txt",
         "title": "Adguard Turkish Filter",
-        "format": "Standard",
+        "desc": "Removes advertisements from Turkish websites",
         "langs": ["tr"],
-        "support_url": "https://forum.adguard.com/forumdisplay.php?51-Filter-Rules",
         "component_id": "oooemoeokehlgldpjjhcgbndjcekllim",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2We4hmp3TwsrKyOb6rF/mCjy9TW3w9n9CD1rZMXUF3U6CCgxH4lps5HiLlxUFaIhhcUEXrGlXbk4TE2LlTv4VS53O23YixZXQ/xMmpWSyBvc3/jBCrAAcvDLAZY53J1T/9t7DNZdpXkX3rNpYB4L5/5dyzQI+sZZoTBe5dLyJOR1uDZJphpXRWSKqBRLn4SJ5uOGgtqG5J4rMhB+SUrNhWs8AyM8+tdoaxOjx7n+PA2Rx7/foty1Bbd7Hfc1Eg0C9R40inJNgH+IDxZ07ZFqiAuY1Z16lr4bwunk7ft4tTafci0M2t86JkoH0B4yiTBKthB6AkmZ0/dejeQeOBszYQIDAQAB",
-        "desc": "Removes advertisements from Turkish websites",
         "list_text_component": {
             "component_id": "gomenlogbembmkbghmaoledggliepdef",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2l4J/f1wAJESK4G74P/2aZMsK+r8oUGB2QIN3Ny5tFxONihjidt9wgmjXQvsR5AYhLamylmH3u9u8mo6NC4b0qVE6imybPgp9/Z826O4VOCBd3yVxe6TCf76tuLSRfUjzreqt3Q6ly0JxgaoKXTWOnu3aoQyg/MnBmZ+REpKcE6W0Pyts1/yGDWs4S37tS2uCEmd2Wi4pUWfmzDE/RtTbhNNxoLoa6GczoeSXZww5emW2LahpE6Y8wGz/mPwjbUn0//T2y4Uqn1/HfMANEF8/t8ykk7cWXB3HdA8abg2Vib+dweCIiV2ZDFcx0l0j/SGCIDKwQYWZZkfF3P7Hp/RwwIDAQAB"
-        }
+        },
+        "url": "https://filters.adtidy.org/extension/ublock/filters/13.txt",
+        "format": "Standard",
+        "support_url": "https://forum.adguard.com/forumdisplay.php?51-Filter-Rules"
     },
     {
         "uuid": "6A0209AC-9869-4FD6-A9DF-039B4200D52C",
-        "url": "https://raw.githubusercontent.com/abpvn/abpvn/master/filter/abpvn_ublock.txt",
         "title": "ABPVN List",
-        "format": "Standard",
+        "desc": "Removes advertisements from Vietnamese websites",
         "langs": ["vi"],
-        "support_url": "https://abpvn.com/",
         "component_id": "cklgijeopkpaadeipkhdaodemoenlene",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAymFhKEG/UJ8ZyKjdx4xfRFtECXdWXixG8GoS3mrw/haeVQoB1jXmPBQTZfL2WGZqYvrAkHRRel7XEoZNYziP3bCYbS4yVqKnDUp1u5GIsMsN0Pff1O1SHEbqClb79vAVhftNq1VQkHPpXQdoSiINQ12Om8WbOIuaNxkrTToFW7XRMtbI3tluoLUSy9YTkCEGah68Dl1uL6nOzOxaMV1iQRRk5Pw4ugTzwGHHL2U2kDYDNrlywK8cUIFgtZskqQ/TF1zF6u9xTGjwjB9X319XrTg2llcojCgj/dllBuXL2aJoDsS3qAVzqbSYxIE6bQU8JX8wv+KCDMpJt/dHPQqOMwIDAQAB",
-        "desc": "Removes advertisements from Vietnamese websites",
         "list_text_component": {
             "component_id": "ooamlicohiiaodkaemgoimcihidbedmp",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3NaOxndIgpo142VxPI2iWEKwvfFbKsQpxZeGzLGbhO7SwFi7AcEBvDOS6Ufc2PQ3Cz7+TxvUO8a4uEVK/SEiNtMhfL7LGlfMyxV17hIJEjWN1ytEEAALjXJFyVkcz0pAhPC0RY/ti378dSLYL9HetA4XfeO0aC7l23dirQMZMRPfSFvzaZtrp2t35PbQCuMqDW9jbPtdwSSswa7wVYFdafaT48WDuMxxKrggWikMBDxE9/Jihd7179Bd0pmlVreBsWhj+LjLUkf+j4UksUiyttKgQ3+5ZyV5k/tzmhN2HaJC9/q+hvboBz1giOcpSb7u4PbmA82o1K62nKS5c77nTwIDAQAB"
-        }
+        },
+        "url": "https://raw.githubusercontent.com/abpvn/abpvn/master/filter/abpvn_ublock.txt",
+        "format": "Standard",
+        "support_url": "https://abpvn.com/"
     },
     {
         "uuid": "319A754E-065A-465F-B09D-3F2C7BF1E67B",
-        "url": "https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/annoyances.txt",
         "title": "uBlock Annoyances List (used with Fanboy Annoyances List)",
-        "format": "Standard",
+        "desc": "Removes Web Annoyances, Supplemental uBO list",
         "langs": [],
-        "support_url": "https://github.com/uBlockOrigin/uAssets",
         "component_id": "bfoofkaohomljmodljoameijbaichadj",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAx6oamYGdGGq5ZITZdjTfIYUdkUFDfer3SBG2Dp/PLpCktna778IR28lrwrA9mlQQDCwmWezRNaX9n/hIEemPwq8Fijp3v2rlXwj2xoskwxNPuHB9qETUZh1K2owZkLngrLR8UJP0kOcpCGCxiQ9Pn8kBoeNsDOx1yHnVmU89UUqGYNwIeSUDcrOdi8f3CZUgtOxMNy5+3s1lrmgWnt8gEpQptBS7G4Ptn7sYtX9HfMW+c8AEluoxtRyB2hcGMb9wZ8fUbYbvLtu5agSJlXi67hSHa5tSAQCCZO4Fd4Xvv5TX3AIaz0dFwJNbGp9HLzm974TfaqFkVWFZ5FdlRvD71QIDAQAB",
-        "desc": "Removes Web Annoyances, Supplemental uBO list",
         "list_text_component": {
             "component_id": "pnoagbonokhdnppohfeemefhjbbofplk",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0BMvGe5WudkwwjswOQ61mbs6L/NNWKQK3kyw10Ew2oRWR5Jggr9IRFc3nT7tIvYZ0l/6tbOzoqM07Z3AW7ASK+am8TL3gw4nxZuduCdEJreJdlTKHxa7/Q0eYyNrTzVyu2zsiSZUFMtrWEhPdptnE15pA4NW7cy2rOWkTyG+nLZzDP1JEov3ZHia42B9RorQLN60dLLhYZl0E073FCra3Tv3wyNwnzvVskcPC9ljRSxH34UYCkjvZH8yHSZE9e/Oda2Tza3HxTy2Dm3Iu1PpfjJBYJCd76ZChlf0Pwb4hvE4YjmZd2EGXNnSpVjUrKDpSSaBORbURkm8tRXFRCs66QIDAQAB"
-        }
+        },
+        "url": "https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/annoyances.txt",
+        "format": "Standard",
+        "support_url": "https://github.com/uBlockOrigin/uAssets"
     },
     {
         "uuid": "BD308B90-D3BB-4041-9114-22E096B0BA77",
-        "url": "https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/yt-distracting.txt",
         "title": "YouTube Mobile Distractions list",
-        "format": "Standard",
+        "desc": "Removes Youtube Distractions (Mobile)",
         "langs": [],
-        "support_url": "https://github.com/brave/adblock-lists",
         "component_id": "lklpombomaoagfjekkmiggppobeeeklg",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmREMTDVEwlJKAm1PUCTZDdcO4TjT7jZn1NiQHPcRUUlA23bK1QI+NwevgJzIz2VpnA8AdHhNeQzYDypEpow5B3MmRr5g5tC57uVuy9qmq8/i5sPFg6zhCL5bxFmHEAU/VdDuYrCYYaNEqwdWpKP9CBoNLezJwRfgCJNjXRpSgQAATVDvxbZYgB11McQTrEqsqXra2wTlrr3t4V5aTyRYghImGFa7Ka4o7APq2q7jhtCnU0/tq8g8ykg+AFlpdlv3YgNEzD4c4UicruRS1C6U2pR6n/eDvnzZleiHo4eSi2HRZS7ayMeZrdi10zowWq8qqNT4pgkDb26vpF2tzT+oGwIDAQAB",
-        "desc": "Removes Youtube Distractions (Mobile)",
         "list_text_component": {
             "component_id": "cpapfkpkeaajehipopnaiihfmbfbnkdp",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA11xzFtkVM4xI3AeJ281iUJUmDGSjWXdNDJkP0Mv7LNdc1fa8hQuc/gOKdU9S6UjxA3HEpHMucIFKMcQZ07A9MUjiP+B/fwxrTrfwqFKyePQkrd05HjhwDgzmfBpCgx9nQjDubEamzsb0yUKj+gL3D13f4tBi7pb5GHhGAY3smwZP0Dp+ydO5ec9fs1AdgLX6kK/mTuCr+oMf9ZOkTp8KxMS6MyN/NhsMG4Jis+mOuRdoBzvF7y7p/BUm3ewVJZ2KtMz2W6/v966kpaPX+PDdKK2qdGcIClq1nFgKB8dcjorPq6xjJhvflwAtXqYXfMD2h/7Pkdz6aHZc8NmVAg4R7wIDAQAB"
-        }
+        },
+        "url": "https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/yt-distracting.txt",
+        "format": "Standard",
+        "support_url": "https://github.com/brave/adblock-lists"
     },
     {
         "uuid": "2D57ADED-3531-419A-9DED-7F8868BC1561",
-        "url": "https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/yt-recommended.txt",
         "title": "YouTube Mobile Recommendations list",
-        "format": "Standard",
+        "desc": "Youtube Recommended list (Mobile)",
         "langs": [],
-        "support_url": "https://github.com/brave/adblock-lists",
         "component_id": "ghjoffpbhhecdjeffpjeejdpjfckigle",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4cZnKXdtGkGBM0pXfgCNp+jaMHVRKMPwp78lfS+B3lPaM8+f6WzzOMTBm4p8NGrDVtw+Ej+z4zLuYPFDtPMIOlpASBhMwjay5NA0dkeLgTz00GYS7a/gTE3uMAz9w3s5m9JzBDWasgN0fnMkPGhs1jCc037Ji+Ox2dGcqNctqPH3I+ODdPiCAZyrgLZxJZOn4bkzlqjaBuwiWdhaHlorwntu7+OkYWXfs+xCFWULWtnAXBZLAQ0z6b+fpAHacHEJxEJPEvY2zAKNq/1BOMNNW0YssjJ4qR01DLsdAAG1JrN5UPVk6ecBOSp/HfDUSEAwemGOIpfxtZS0Os3QZShWBwIDAQAB",
-        "desc": "Youtube Recommended list (Mobile)",
         "list_text_component": {
             "component_id": "phdmgpanpejkbmbljlhcehpadabljfbk",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAv1vkW0NQdDtdNQt/BZ9M803R3dHx3ow0XN3rCh4vo9lXpiJot7RIxTSo2qKUWHype4g0MCL/NIiFq6jY0rdBpCP5hv6GmFf6r8uZsurWA/FVH7hzY1tcJ1t5zBZUufamlWQjeUdCkflsrP6p07JK3SR1WFi8xcTT2uQ8Yrkb6ioq5C1mBOljbVPJuYzk99acKu55lvWG2uKH9aDuHd0OuK8+CJycWVDdeFoGXuGHlTfURDbmgnv2P23jctE0viEH+vuk5ecofhmBG0rXpbF/fqJJYQu6DINIyc4E9NQ8W2ryutTBo7r9ZbW68uiAe+7UVrMkFagjl66xK0WXNcGBlwIDAQAB"
-        }
+        },
+        "url": "https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/yt-recommended.txt",
+        "format": "Standard",
+        "support_url": "https://github.com/brave/adblock-lists"
      },
      {
         "uuid": "78672887-A098-4D2C-B0CB-A3DEC4834DA7",
-        "url": "https://gitlab.com/magnolia1234/bypass-paywalls-clean-filters/-/raw/main/bpc-paywall-filter.txt",
         "title": "Bypass Paywalls Clean filters",
-        "format": "Standard",
+        "desc": "Bypass Paywalls filters",
         "langs": [],
-        "support_url": "https://gitlab.com/magnolia1234/bypass-paywalls-clean-filters",
         "component_id": "gemhdipceojibnafnnnjnkijihoonobj",
         "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA6uj1pHwtluCMMXvrq5MJL5ZQKVeeC5u0uA4IdF8sNzlwa2mhdCR8hpmaFBl4vfvCRjjpdp86AvQmQjXThHdNHwQRFAmEOxoyjpLNbCeGT7jzQfGSEwfhmoRnm8nAYj3/tCb9RM/RdcJGimAYDlDygBEtZSTLM/qa4ehPw4Twabh79zFL69rXnabBPqNosGHwrEMrBTqlMwJnHFa7WbrarZtUen9sxgqkhx3+yKTS2b5K2aKwyLk4lCljKViBlsJl42FS4oV5odDIxKdYXhYlqohntZcnf8PMEgd8WE/o7D3MnB/T5J3UyhKkf+YtxMP8zORNxUKAaKCbYIQMp5K4XQIDAQAB",
-        "desc": "Bypass Paywalls filters",
         "list_text_component": {
             "component_id": "mjhbdghipcamfoojbeikdojibeelbmil",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4p2Fx/w0R4RVscwM1bobz4jcc40AkE+Ccp9azcUreKZWa3I75hv4G9MQOp9xHvxXVxcIVqRiGDdSyyDHCe+YMbYMQJhGdTEItPx5c3IZ/Lq35gJXLBb5+dqW+g5lp9I8+19YN5GLnkVU2snMosJ+ie6rkQaE2zoFOiPf7Uiode5FroCsgDh+OZpOeXkbbOWUBgNY3zaAZ9PY00k4R327Qk01LUfhokfgZxcvxOofIuIR992q5xxPreMHat2ZBDbEuLAuNda6/cJqhn6M4cCyHJh4+bv9GjcBGtd/QGiXD/s48fPfm453wYjd+DAtmLwBjQOsw4gcPmt5gTui6eAkOQIDAQAB"
-         }
+         },
+        "url": "https://gitlab.com/magnolia1234/bypass-paywalls-clean-filters/-/raw/main/bpc-paywall-filter.txt",
+        "format": "Standard",
+        "support_url": "https://gitlab.com/magnolia1234/bypass-paywalls-clean-filters"
     }
 ]

--- a/filter_lists/regional.json
+++ b/filter_lists/regional.json
@@ -10,9 +10,13 @@
             "component_id": "mpgdjfnjjmglioiflfioiappfbdbkeno",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAr3arBYpWfbSQIYLDp6nVB4aQG+2r5NOh1n5YuD8zhYa8lN4G6m1/JqcMkbK/KE1ujqG4q9Orh5d0FjumAtdzw/KkEEg14OKmu3+xeHxV2YbIDJGEW7aTMwlqO0Nz0Da+Z41hbMLcjjCHl2KrSoAM4ogUYVtYW1GLplfH3P5ss+hM1qrwBsPI+pXIMyK1ZqTc8552+SxQFJ7RFbn1h1t9cSu0JoNw3SiIGmrOT45ZROeQ3D5tP1MCPqnOsanTeo0NTnt65AuGhj5EvOcSGZnbhhQulwpzA72r1reQ3wBlXjdIR0w1S1wAn75LXYgPcBMaST3Cfais0hs/eihWQceS7QIDAQAB"
         },
-        "url": "https://easylist-downloads.adblockplus.org/Liste_AR.txt",
-        "format": "Standard",
-        "support_url": "https://forums.lanik.us/viewforum.php?f=98"
+        "sources": [
+            {
+                "url": "https://easylist-downloads.adblockplus.org/Liste_AR.txt",
+                "format": "Standard",
+                "support_url": "https://forums.lanik.us/viewforum.php?f=98"
+            }
+        ]
     },
     {
         "uuid": "F61D6B7B-4110-4EA4-9C81-38FB4CE90AEC",
@@ -25,9 +29,13 @@
             "component_id": "lbnibkdpkdjnookgfeogjdanfenekmpe",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvLwepAP2UzEBpQraDyQ4rbGWmswgYLEyvEssFGmZ9uAHj3jtP2vE2w4AwpIsyg6zaD2Wx7fsgPTHxb1hZrT7lMK7RJzzrAeINlfbNwzxte7lkedxLdEaq+HrQunnBK9MY1fSonVmMohYCi7Gk+loUrGnQpuspVI6VJJ4N34sb8qiKueyx5+IyQpIBNPclhGs22yxohHN15r9sOcqsZ9XwNR1r7wZHE+pK1gu0a70zoY0WPPXFHZSHlbCz4VxLWeHwWdnx3yVOkgVOiacilCuutcptl+09IVFYHxTjquOZHZHcLFM78nju1K4R4V3IlEaXjxnYTfo+VJBQniBD/T81wIDAQAB"
         },
-        "url": "https://raw.githubusercontent.com/blocklistproject/Lists/master/adguard/porn-ags.txt",
-        "format": "Standard",
-        "support_url": "https://github.com/blocklistproject/Lists"
+        "sources": [
+            {
+                "url": "https://raw.githubusercontent.com/blocklistproject/Lists/master/adguard/porn-ags.txt",
+                "format": "Standard",
+                "support_url": "https://github.com/blocklistproject/Lists"
+            }
+        ]
     },
     {
         "uuid": "FD176DD1-F9A0-4469-B43E-B1764893DD5C",
@@ -40,9 +48,13 @@
             "component_id": "fdmemomgcgpopbhhmdkdedkphkglhopj",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0Yrj54S5rhxkhRCeNs0zpXclTFpJUmBKcPIYEbISsmgfGIKwd0GpR0IGxdENuSK4hEzFBpsQLLRcmipEHrDuqeaeaCkyLA7oBsb5REK4nBgsAB7YBekrEQQyOzoEG16RGqcIHw+0ZTppDPmF4Cdidyn9S77U481+W2bEWOp+NpFqPamA5pBaUyXeLgTB6dBRuUPnjjuXwZRF213W8HMI5T0c9HIuLipW+P3F7PhxD84F70dhuCUJ9X/DCjc5CFlWw1UPu3dlHT/sd15qR9glld9I0yGEXgQuPccZCBhnCWLfslaqZhgImmfqI1YBAzOaWED/q1y5hgh/8ru2RjOQ/wIDAQAB"
         },
-        "url": "https://stanev.org/abp/adblock_bg.txt",
-        "format": "Standard",
-        "support_url": "https://stanev.org/abp/"
+        "sources": [
+            {
+                "url": "https://stanev.org/abp/adblock_bg.txt",
+                "format": "Standard",
+                "support_url": "https://stanev.org/abp/"
+            }
+        ]
     },
     {
         "uuid": "11F62B02-9D1F-4263-A7F8-77D2B55D4594",
@@ -55,9 +67,13 @@
             "component_id": "hmnnhojoekmmehfpmeegehbmifiijobb",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxi6JL3FFNrYHPp90XALlCIOuC0/usN2tZF8oGdXe5v9KFQaNlvV//nJfYOiqyssh08FGsglQqekkUZxKdSsBQ8+7kPyBsrEepH4mWvcWNP68ONMjrY+onYM1csKXSe6aiQ+dN8CuJpcaTD5KJLBSCSGSfYqijkGshFUIHwpj7QnmBkdKzAChnynx88+c6lFIyMnxYjosXtL2Ioi/DFAVpb5z6+smNN1ZSo0lx3NNlCF/7ESN4SbLbCpcYgvs7mKuA4+i3/vQofBHY+YFy4WnGQf3l+QTRNk/uV7J9IKb/11U8i4LqxZ6ila4Ni/6JFzaQBfrvt/Nhy1g2Jkl9oWBNQIDAQAB"
         },
-        "url": "https://easylist-downloads.adblockplus.org/easylistchina.txt",
-        "format": "Standard",
-        "support_url": "http://abpchina.org/forum/forum.php"
+        "sources": [
+            {
+                "url": "https://easylist-downloads.adblockplus.org/easylistchina.txt",
+                "format": "Standard",
+                "support_url": "http://abpchina.org/forum/forum.php"
+            }
+        ]
     },
     {
         "uuid": "CC98E4BA-9257-4386-A1BC-1BBF6980324F",
@@ -70,9 +86,13 @@
             "component_id": "npcnkjiaolpnapjleimicclmdcccoeme",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsfs3LRQT1thqn9t53KmWtvaKeuBv7mH5ydazOFixM3Uutz83/PZ3Obsvux1/8JHDah6AvxBQtjoZy8jFKZNtqiHXxvkisj5DAL/O/rCwvZBHTXLQqodBxsCpnjAwGG9/Rqw1kOwKAb4hIHy+5Xq1hF8oj3eHD8WnIhvblOMYg6L4gVSCxpJOchPVLs/5K4sovGDxItmsJJqLYrsxtuqvsatQFj+GigrMoOAA3yOPIJDgr4/E+nqD9su5c7+3OPggr42B2+we9rwWiDCLQvXOiV0NKUavlV8P/8AbX0TG4RxTNEUTpGkGkyEzO+bCWV5/Ne+s8ifz9Bw68xW8zaZ22wIDAQAB"
         },
-        "url": "https://raw.githubusercontent.com/cjx82630/cjxlist/master/cjx-annoyance.txt",
-        "format": "Standard",
-        "support_url": "https://github.com/cjx82630/cjxlist"
+        "sources": [
+            {
+                "url": "https://raw.githubusercontent.com/cjx82630/cjxlist/master/cjx-annoyance.txt",
+                "format": "Standard",
+                "support_url": "https://github.com/cjx82630/cjxlist"
+            }
+        ]
     },
     {
         "uuid": "92AA0D3B-34AC-4657-9A5C-DBAD339AF8E2",
@@ -85,9 +105,13 @@
             "component_id": "fbljdmoohhbifebddjnbbljgencmpjlb",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnqEZcpRqGk/mgGi5UC2hZSMDJTesTp/trL+T56MTsS2Ld6ktt7NOSoAeUNLjVO2kc840jwtUkgBTO93SOkaC4j4GuVU1mH6hGaGrvAGCEQgcBIIBBsCB1HUUFmWMlaOK/tRrysZ/ugummrhVicxdzYUK370dK2dj13WN68AR4Q2Hvo9gEdbhlG1o0YiGew5zF0BvmqoMK0owZIxGs5Gqq3enGqURU2FtlDBu7Tmfnr/Ep5l1KOSG87Gk2wlYR5KhkX1N6p2/EI167udioZK9CndnxqEIVq+DuYR0obwouV8lzxInZ07ojD5kW3O+WSlcRLCzCaRPFhQMMi7sLLxqzQIDAQAB"
         },
-        "url": "https://filters.adtidy.org/extension/ublock/filters/224.txt",
-        "format": "Standard",
-        "support_url": "https://github.com/AdguardTeam/AdguardFilters#adguard-filters"
+        "sources": [
+            {
+                "url": "https://filters.adtidy.org/extension/ublock/filters/224.txt",
+                "format": "Standard",
+                "support_url": "https://github.com/AdguardTeam/AdguardFilters#adguard-filters"
+            }
+        ]
     },
     {
         "uuid": "7CCB6921-7FDA-4A9B-B70A-12DD0A8F08EA",
@@ -100,9 +124,13 @@
             "component_id": "oegebjahecghlckbhkmojgnpcgdeajdi",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxtk14SdoCDoN+0991kgseVmUETwAVlWN+IHmyX6VM4fd4Jw4eRk5fflxBd4EsQIJQ9hCDxO/jW2YlGvz09Aj45OuxZ/A4T1h8w1IwyEJOc6NvkafVVaR8kvzlYq1sYsuPDiC3ACMx/AvmHTRoLDtJsH64H106ZjvMb5NzeJrhnu37Msc9w2tnmtc8XsX9RzTFnqp0jDeboOYoDiBtEo8DFSzI0CT3ffTMK04yKh/kdnslxTESHyDS69jo0SFRT0yVGH5xlb/N6FIqtB2fROlOrn8jGlr/3iufnvrKylRdMzx1aytHSK17yJiJe+P4YjlH4kjpFMTJAR+/I/SpiDu0QIDAQAB"
         },
-        "url": "https://raw.githubusercontent.com/tomasko126/easylistczechandslovak/master/filters.txt",
-        "format": "Standard",
-        "support_url": "https://github.com/tomasko126/easylistczechandslovak"
+        "sources": [
+            {
+                "url": "https://raw.githubusercontent.com/tomasko126/easylistczechandslovak/master/filters.txt",
+                "format": "Standard",
+                "support_url": "https://github.com/tomasko126/easylistczechandslovak"
+            }
+        ]
     },
     {
         "uuid": "E71426E7-E898-401C-A195-177945415F38",
@@ -115,9 +143,13 @@
             "component_id": "lfmefmifdjlfneapckmpkinmlofjehbp",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmvTOXmS56FBoh9eAsPUIAFXAYnwmyJC9HgLEtF7D5pkac6WkPAOOeidY+wJ0A2u58hBYw82f/8COkznUUiq7Oubb6+zdJP7lsTYbhN9yoPm+aw1vLucSa2O+O9Xhvp/0bT1bABtdccb9WrRT5HlL+BiHtwwHVZ0KLuX+k1IM6jxWD3DxKk7mnADxIOobODspLGkmduTMzVYygbMKf+0p478Us99aqK8oEMMjTL8IMHfdwFUrTBBbhS8mVkioNUFCEzeXFowhnWeoN6ysjmIcNN2STeVptCBXcaOAYePCrbCDcRzeOTBr4mu4U13Bune87VC+WJkTf+E9BDncTHjGUQIDAQAB"
         },
-        "url": "https://easylist-downloads.adblockplus.org/easylistgermany.txt",
-        "format": "Standard",
-        "support_url": "https://forums.lanik.us/viewforum.php?f=90"
+        "sources": [
+            {
+                "url": "https://easylist-downloads.adblockplus.org/easylistgermany.txt",
+                "format": "Standard",
+                "support_url": "https://forums.lanik.us/viewforum.php?f=90"
+            }
+        ]
     },
     {
         "uuid": "0783DBFD-B5E0-4982-9B4A-711BDDB925B7",
@@ -130,9 +162,13 @@
             "component_id": "dcfccddjfmckaigemleendolfmmaaiii",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAx9d8o+kM4IcgkHERTS82gnn8jdvOaTqJ8YPV+vbiOEzS3ntIawegkGeGB5ZQzxqBdV/v17L1cG9Ze5RvqdHw2eqiRPWREwUw5G3TvvH4NAteGtx8+9xv82s+Vt4skM4bUfvm75uroz4wpAFpCwgpHnR3w8m3cnq4vTog/z4xVd6Z2cR5VSbuH/9S9RoboyLrse95XxMlb4mLDi+vIf9xbLrOYTknw3LQNrSb89+LL90h/XeyDHuHkfeqfAZaJ3g3E50u45nFhgHQQEz4V0vg1jL2PMmQmm01MrZCeC6o3FbTZXHReH0X2EDgaxhi/nq4SSYlPLuCvuHIQAojGu0YFwIDAQAB"
         },
-        "url": "https://adblock.ee/list.php",
-        "format": "Standard",
-        "support_url": "https://adblock.ee/"
+        "sources": [
+            {
+                "url": "https://adblock.ee/list.php",
+                "format": "Standard",
+                "support_url": "https://adblock.ee/"
+            }
+        ]
     },
     {
         "uuid": "AC023D22-AE88-4060-A978-4FEEEC4221693",
@@ -145,9 +181,13 @@
             "component_id": "cdbbhgbmjhfnhnmgeddbliobbofkgdhe",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4txGiQ3yLerqLDucoT7AeFjSShvHcUlEbW4XTf5Fg8qi9GzXVXSS1PLZZSYX94fIch+0gd0bFBsSuN5vJVjR/xIyYaS29uvav5WJ/p3zt+mqW1eDarQ3CS0rsqWHjeTQJjaqw/TY7zS7/QJFspQro6/tOAPivWXYHV7kWVUtpuX8vcLLM11mexxKUEcbTrFwTmF3aOZcQnCTTR1NFV46v9MxnBj86RZQ9v/APjDIt9d9l8/bvq5Jp4w+8sv5ctb6nxSBSrhyVlbYe2eVrdVwOrcKijGA1ROfEk4A/R8knajBl6ihiXlGteVqIOrka3onyB0y8UTP++a7TZey85yXUwIDAQAB"
         },
-        "url": "https://secure.fanboy.co.nz/fanboy-cookiemonster_ubo.txt",
-        "format": "Standard",
-        "support_url": "https://forums.lanik.us/"
+        "sources": [
+            {
+                "url": "https://secure.fanboy.co.nz/fanboy-cookiemonster_ubo.txt",
+                "format": "Standard",
+                "support_url": "https://forums.lanik.us/"
+            }
+        ]
     },
     {
         "uuid": "67E792D4-AE03-4D1A-9EDE-80E01C81F9B8",
@@ -160,9 +200,13 @@
             "component_id": "omoaeaghhgmiojkeaemjkpkmelmalbgo",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAy/xbKx4WIC1LApciemKEs4rUz8MspYGqLzmhQwIsp6qOqMKiYA9pqOtUXx2TYRPkZODISGSsoqvTZ6Uv7Aerq0Bu06UiDy+H4yU0jFZPVDKsMfj9Ky0DAy7ocuetTIps5Aewx5S0S8g9zeI14PluhqsXlTMLQAqkFeUSsML0qHo94Zgx4T1AwHH8IjvsHB1456OCRjxlTICGL0hEwZdEV2rVYWXtkLzEDZ6guPmvEVKZIhey1DG9fXV57SFCLmBC2eTlv0rYDqqgK6KSUeqyAIHV4eiaqIPMgsRFVnE9JD/Q9xrjeAuFc3pslx4YKI+iuXgfa/8jGpPuKqcDX51F/QIDAQAB"
         },
-        "url": "https://secure.fanboy.co.nz/fanboy-annoyance_ubo.txt",
-        "format": "Standard",
-        "support_url": "https://forums.lanik.us/"
+        "sources": [
+            {
+                "url": "https://secure.fanboy.co.nz/fanboy-annoyance_ubo.txt",
+                "format": "Standard",
+                "support_url": "https://forums.lanik.us/"
+            }
+        ]
     },
     {
         "uuid": "7911A1CB-304E-4CDB-ABB3-E2A94A37E4DD",
@@ -175,9 +219,13 @@
             "component_id": "nbkknaieglghmocpollinelcggiehfco",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAs6ib1E68QTHuz/TdEn+ck++Okbcf5xDfQjkhpTb59fnjm0rjII6MV3rWLEj5dkOvpAVzDzFCcyC/JJ/SYIY7nFRQl+ptttd1nLWNu7qewFGh2tezwuEMzPlzQr+KK93Yh0dooCC9KniR/0+kpYeGqBC8tBGz8f4KoV+/zTfkD/47pztflCxNJfrAj4P0GDQhvz8lBtnm6Pa7tGOMhksnMsYWRWsYs6uvjsfd+3uYbiCYa7lEMjZZKy7dHg8hPSUeGZo28kTqYFXufH5jY3q7Luk+dQey1+m1X97KLPOtmwaLFCFqWBha5qFMg/mgzczlaphReFUycwrYVjjOICKrYwIDAQAB"
         },
-        "url": "https://easylist-downloads.adblockplus.org/fanboy-social.txt",
-        "format": "Standard",
-        "support_url": "https://forums.lanik.us/"
+        "sources": [
+            {
+                "url": "https://easylist-downloads.adblockplus.org/fanboy-social.txt",
+                "format": "Standard",
+                "support_url": "https://forums.lanik.us/"
+            }
+        ]
     },
     {
         "uuid": "690FF3B4-8B6B-4709-8505-FEC6643D7BD9",
@@ -190,9 +238,13 @@
             "component_id": "kdddfellohomdnfkdhombbddhojklibj",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAr2V5xKHqddrLQr8mNlL4UQGUYfK62ftOlacYb23wPWfW1We4jIOHtYqHg81D7gYckSBejkLh2HqmGa6RxehFTQf8g/L8G1dgzQ10VrQF4STNJiva/EkhcEJHai279biESL6HLVTDun2BnXENxCUR7hc8hDM4xw2ZlaqMMUtFJwhQW96dzbLVG3yP7k8TDwX1dRaAa/Pe+Ie7OYhIUQp4I3rWn3GmhfKBxQalHce/7lQpZwCP8Q/Tz7D8GzvMu+dYm5LnP7LUfC2SdSM0jm3qqwKkWlT1W05tsce4vk2cnxwUUWOAh60TSzQ1d1DX/PfJBUzQG6gkWRMxGNLi+T4i9QIDAQAB"
         },
-        "url": "https://secure.fanboy.co.nz/fanboy-newsletter.txt",
-        "format": "Standard",
-        "support_url": "https://forums.lanik.us/"
+        "sources": [
+            {
+                "url": "https://secure.fanboy.co.nz/fanboy-newsletter.txt",
+                "format": "Standard",
+                "support_url": "https://forums.lanik.us/"
+            }
+        ]
     },
     {
         "uuid": "2F3DCE16-A19A-493C-A88F-2E110FBD37D6",
@@ -205,9 +257,13 @@
             "component_id": "bfpgedeaaibpoidldhjcknekahbikncb",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA310+gKMk4QUl7K23eSXHDukkg1Ped5At02N11zRHJf52mTFy6jnUgA7vo1hkARNHHJDwI9dSyfYsAtrw9qgo/V9ygDBkgShHyYC7c08pgUkdlciaZepj633yuMyyFK9lo3PEF+f1kOodE/Vq4ybJTChDcotuT5bAi57d1Jiizgv5Rz4W9ZvqsWOVbiclQTY+28wTpfuCLznV7mrx7kvm1D2aQaLaJ2R/936DkXRqUn8Ty9GGGaHqx9HK2JgB5RjwFk0esarZyua0kRB5JwMUGu+TsEiGgDpCbRka3nfxItwhoWGBYPwdapkdUr7l3RdeTCLUWmCBdkpmDMhbrG3ctQIDAQAB"
         },
-        "url": "https://secure.fanboy.co.nz/fanboy-mobile-notifications.txt",
-        "format": "Standard",
-        "support_url": "https://forums.lanik.us/"
+        "sources": [
+            {
+                "url": "https://secure.fanboy.co.nz/fanboy-mobile-notifications.txt",
+                "format": "Standard",
+                "support_url": "https://forums.lanik.us/"
+            }
+        ]
     },
     {
         "uuid": "1ED1870B-997C-4BFE-AEBC-B67D679BAF3B",
@@ -220,9 +276,13 @@
             "component_id": "cjoooeeofnfjohnalnghhmdlalopplja",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAv1O0sayAdmrsaqTddCEZwwHvpjjCbR/2qYj0xh9FsFMS17yIHpZRTZw8F8b0NFDAb/hIuIpNeaBXZUN/oPG9eWv4GoV0fDIr9UST5WzB+zPBYgSV1S8TkqLnkDvE5sTmzG98sd3VL/L7PeijOCidcKnSyG5hkP+UNHmKUaRnLlUTM/ificlkjR8IKMNFrC+e4PjHkF+EtBFLKR9Qb9iEJHEjDbjEgtozDs3IrGGsrK3WF4A6iqD5zMX50FvUAqPkAhm9jnfyISarfwkI5WlhQ/mmA0c/U5lXFg5v7MoLR05ns9G40jqOc8jFmzVaayBVF/7RaR9wxVlxEzzMDoA37QIDAQAB"
         },
-        "url": "https://raw.githubusercontent.com/easylist/easylist/master/fanboy-addon/fanboy_chatapps_third-party.txt",
-        "format": "Standard",
-        "support_url": "https://forums.lanik.us/"
+        "sources": [
+            {
+                "url": "https://raw.githubusercontent.com/easylist/easylist/master/fanboy-addon/fanboy_chatapps_third-party.txt",
+                "format": "Standard",
+                "support_url": "https://forums.lanik.us/"
+            }
+        ]
     },
     {
         "uuid": "1C6D8556-3400-4358-B9AD-72689D7B2C46",
@@ -235,9 +295,13 @@
             "component_id": "afggnigkiebjlahlhcjgjahbhfikcipa",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwHc3AWJORkPvjY4vthcP1CaLpG5yIga3gADJP4jAfRaqcxQp9f1IIGvtK9+nUerpaomRMTjJYNm1lQk0uq9EAcQjdb1JWl/MOh3OGlhZ3oYLTNqMW/ZbMHrfGgGD33WXCcQElu1nNOHUxJqaFeyOZvI/4LumYrlpADdotoVSJ1pMhrj9iQg+a/GAddBaAGEqYpjF4tNBGPTufmj5L2Grh6Uaue5sLFzH9lNi/VYSlCcXRDrz97EO0tjyNrEQWffuamAAd/ArKDSdjvfAeohGEyTeR5xPq5yysxBQqzryWK17fg9MtS0ZIGBbSyAwT8wctJ9XmpMnGFRL7sXqpYb6eQIDAQAB"
         },
-        "url": "https://raw.githubusercontent.com/finnish-easylist-addition/finnish-easylist-addition/master/Finland_adb.txt",
-        "format": "Standard",
-        "support_url": "https://github.com/finnish-easylist-addition/finnish-easylist-addition"
+        "sources": [
+            {
+                "url": "https://raw.githubusercontent.com/finnish-easylist-addition/finnish-easylist-addition/master/Finland_adb.txt",
+                "format": "Standard",
+                "support_url": "https://github.com/finnish-easylist-addition/finnish-easylist-addition"
+            }
+        ]
     },
     {
         "uuid": "9852EFC4-99E4-4F2D-A915-9C3196C7A1DE",
@@ -250,9 +314,13 @@
             "component_id": "flnkmpokemfpaajmiimmjeiandgoodgg",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwwUZwUB8V3M17u9iE4xJlqee5tpabVHr4SUZJMdcxUVYi0gPLSQfWHNUR9HqXy4/b92OmPwOHcp1d7gereg8ave7d6syQB3R6xZLM04ESK949zUAzuYGmTSGPgBmC9O09tAw+dmHrHNXi2zKUf/bU0nOXyYtRqPq9UYxIIxq51nqgIqvUdvX2iwVPGVEXOxgKG3zCF8Z4U9tImWYYAq2cb3LbM2+b6w++PsnhwN6XIFFV2KsYVhtrOnzpgE3M+1cI2BT6N9prYIyP55MHfvU7La/VfqgmRVjH+qASJw0kGy1T/c7R4DLPHaND1L0MY7GjwRxAgPct3eTha+weL01vwIDAQAB"
         },
-        "url": "https://filters.adtidy.org/extension/ublock/filters/16.txt",
-        "format": "Standard",
-        "support_url": "https://github.com/AdguardTeam/AdguardFilters#adguard-filters"
+        "sources": [
+            {
+                "url": "https://filters.adtidy.org/extension/ublock/filters/16.txt",
+                "format": "Standard",
+                "support_url": "https://github.com/AdguardTeam/AdguardFilters#adguard-filters"
+            }
+        ]
     },
     {
         "uuid": "6C0F4C7F-969B-48A0-897A-14583015A587",
@@ -265,9 +333,13 @@
             "component_id": "onooookdmjmijocbeafcldnbfiaobhjk",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAs3sUB/utZpzoNR8aq6FlVWLtCcYC3cl6V6mX1Kg9gUZBCJF4iH3YKlE73lS8zaCO0jnaALUHX2MUFtZvR2qXfHxxiZdlBmGMGfMMqwaTwbRMW0NwhkXfAc7MW3rD0gO0o/FKqhBbc64WefI8TCKwWFSpJCKgBrZK/b3eTWJBg2kv1Zwqd3fB30j4pbi6G8Q+7nryRC8LAY6f+r2MneBoKwJBEXynkq4RJuj6xVaBZAlLoBTn/166tQaoOHf3L9L9CvzpElprKPpC+k3oBTuJqdQXqPafilhpt6ooHnbiBr1LDrV/jHG+YZ0AA5Brjw26ipi5jSn864VsCysGwoLYQwIDAQAB"
         },
-        "url": "https://raw.githubusercontent.com/kargig/greek-adblockplus-filter/master/void-gr-filters.txt",
-        "format": "Standard",
-        "support_url": "https://github.com/kargig/greek-adblockplus-filter"
+        "sources": [
+            {
+                "url": "https://raw.githubusercontent.com/kargig/greek-adblockplus-filter/master/void-gr-filters.txt",
+                "format": "Standard",
+                "support_url": "https://github.com/kargig/greek-adblockplus-filter"
+            }
+        ]
     },
     {
         "uuid": "EDEEE15A-6FA9-4FAC-8CA8-3565508EAAC3",
@@ -280,9 +352,13 @@
             "component_id": "ldnolaledjfkfgpjkbkcfjiaejeeanmh",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA7xknL/MMlSEoLkHDXwyP7S9c2e9q2bYvfBeaA0ZOQG4O3hB0AInjki37iHINkQX/UAEprDDqwNOO0Xp/pWBWItrFYkgPmgfzoaMZ7PnwUiA7/+9Z+JoKJcqJTWI7VlVmUpeclWcL+hqdhcjVGdGK4Y8wupADUpasqsG0mjwlpQ4ur0+G6qJIvbYB95L6Jk1OjwE89RjxYQNPw0cb0bxWUDZ1uLSJHe6eMvMH4P6V8ihwltHG0FpZ6B9U2uV6r1KeTWCbfsWJJLPmzCW861/lSJtOSBynVcsS8m0vD+UHFZn0IbqoLOJZpqvtZCTjl5pC6WOY1TP39J5WoLJtXXO0mwIDAQAB"
         },
-        "url": "https://raw.githubusercontent.com/hufilter/hufilter/master/hufilter-ublock.txt",
-        "format": "Standard",
-        "support_url": "https://github.com/hufilter/hufilter"
+        "sources": [
+            {
+                "url": "https://raw.githubusercontent.com/hufilter/hufilter/master/hufilter-ublock.txt",
+                "format": "Standard",
+                "support_url": "https://github.com/hufilter/hufilter"
+            }
+        ]
     },
     {
         "uuid": "93123971-5AE6-47BA-93EA-BE1E4682E2B6",
@@ -295,9 +371,13 @@
             "component_id": "olkjbfppmeijhkjhjjmfdbloighaigmh",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxNZ6zkktNhRLBkb0qCtQqkqt8mNTapW+0dO8s23+cjHz/pcVHOb5dIWvuF1OtyZOYFojIhx6GmTNPQ/RtwMO5TSwUbLQTHmN/n+e2/kalV0OO21SAXOG4C7myNGa3FClPRTY9vGmGLCtMGkak5I70CbaLrjemO27gxrWWi2C1vfYHzzCkt3wriY7ZE8Xo2SGZSJ2z52Q/xMJVviF2xXXnL56ZvpDifoM3KYMacXPMa9nzOvZ6KHXmmqHKFNl59LmujK1SH2p8sPbz7FykXVgfZedU8Ul7qfLWwGUcliLlALE6X0lLvEtiX60nz3dZIrvZAfagsjayDsCydf0lQ79ZwIDAQAB"
         },
-        "url": "https://raw.githubusercontent.com/heradhis/indonesianadblockrules/master/subscriptions/abpindo.txt",
-        "format": "Standard",
-        "support_url": "https://github.com/heradhis/indonesianadblockrules"
+        "sources": [
+            {
+                "url": "https://raw.githubusercontent.com/heradhis/indonesianadblockrules/master/subscriptions/abpindo.txt",
+                "format": "Standard",
+                "support_url": "https://github.com/heradhis/indonesianadblockrules"
+            }
+        ]
     },
     {
         "uuid": "4C07DB6B-6377-4347-836D-68702CF1494A",
@@ -310,9 +390,13 @@
             "component_id": "femdbljnkmindcakmnbjhfefepeaicnm",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvr/tGn/LAkKrRrt9PVmtyFvKMhSEVj/OuUsD3Jorj+U3TU06Akg8YkGg08rrfjuZjFTtBoniCgtQsnpIuCaRhN/2u95EkGxsS92932YjQQUDMw2chAWaaFKJI1bFSIvvuPAK1lT9RuW/Aa/rpOjDpAZiszVoVMu+ZGNvkheBVm1HbU5rPB24x2kdayzH87wcJS9GxApGa29cXUNUmCZw7w0JNqd76/i86SZBdjXtlPQz1LynLTGyyCUC2sqlcn+lVNVTkGA86EQwM/GTrknGaqyArIoeJMgoZ2WCOOozz0RO6RDPbDHemLE/9+ROHxFwtjhiXbSR+8bbUlKQI2THvwIDAQAB"
         },
-        "url": "https://easylist-downloads.adblockplus.org/indianlist.txt",
-        "format": "Standard",
-        "support_url": "https://github.com/mediumkreation/IndianList"
+        "sources": [
+            {
+                "url": "https://easylist-downloads.adblockplus.org/indianlist.txt",
+                "format": "Standard",
+                "support_url": "https://github.com/mediumkreation/IndianList"
+            }
+        ]
     },
     {
         "uuid": "C3C2F394-D7BB-4BC2-9793-E0F13B2B5971",
@@ -325,9 +409,13 @@
             "component_id": "keclkbppmfihehggeadflldbjpolcpgf",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArAhgRAugxeTTvhXNSRQJ9nE1mmECE9i6HgJjNhyG/XXIKWSzCcbu5wmjOPN11iLjNVHdLZMcKnAqgFbieAVxVRFJdWG6V//E5QZRjZ90g+OCgE7wx7W3BoJUynOWirGuaJUyYv8T6qvLqeYm6RtPMgrfZGxUJ9+PDWCtz0e0St09RtXdPhr4Ft2Yk41xda8D40rzgr+tnNo1FwSdysMbLA5xjD7pqSVNR0b/ivFt8S5o6klEifZywqlmNcfpeLFqhBBfNGGr6xIy0EGxo9HNjdQ5lrn9Cx/bL9kaKiYKuGOsERkSNfrGipnDMZqtTGSY1ECEXaY4IiXVkqYJ798egQIDAQAB"
         },
-        "url": "https://raw.githubusercontent.com/MasterKia/PersianBlocker/main/PersianBlocker.txt",
-        "format": "Standard",
-        "support_url": "https://github.com/MasterKia/PersianBlocker"
+        "sources": [
+            {
+                "url": "https://raw.githubusercontent.com/MasterKia/PersianBlocker/main/PersianBlocker.txt",
+                "format": "Standard",
+                "support_url": "https://github.com/MasterKia/PersianBlocker"
+            }
+        ]
     },
     {
         "uuid": "48796273-E783-431E-B864-44D3DCEA66DC",
@@ -340,9 +428,13 @@
             "component_id": "oimegboipnkgekgoccmlljjlhhbjaoil",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA62u5aa9kHm8s001ehhl+tuEE0bSSUxxBPfpSWC7Xr9zwObVpq63bSUAQqgqy0RW4RIq9X2etSmtpYryr10FglhV3TvMhZ/JxAX9VcPolrgG+tdMO+000+S5T5N/qpgZB1IycedaHNQ2NEFBSZEU7wqTIqHdYjAerkX8yC13Qg89FxU73Ygkq+1hQl1ZUr18f2gU6WpG5Nv1hpwwNQKJ5mn9K4d9uE2W7croqFANvEcvG6teAnw2JCWi42uabN8Ec35nff2r3BPCryCuAx3bsInasbDHNFlww6HXHBVfBr88y8v4hursSGmKShSFBMM2IGcRaF7Sia9fWGyQkBjiE7wIDAQAB"
         },
-        "url": "https://adblock.gardar.net/is.abp.txt",
-        "format": "Standard",
-        "support_url": "https://adblock.gardar.net/"
+        "sources": [
+            {
+                "url": "https://adblock.gardar.net/is.abp.txt",
+                "format": "Standard",
+                "support_url": "https://adblock.gardar.net/"
+            }
+        ]
     },
     {
         "uuid": "85F65E06-D7DA-4144-B6A5-E1AA965D1E47",
@@ -355,9 +447,13 @@
             "component_id": "kdakdkdknmkkafefhcbngpinlfoopoej",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA6OM0Ert1wGZ5bOxBO4Z8qikIwBWLZpXnL4Fy8zhu1NOfCODMHxv4WdEZLaQrSgpInAeHi7u0d0doNrBx96wwRJmm4Ng+HlP/dHtihNGWz1yAcrRoKzqQzwsb1Ty+4TPeKRcJEf1JJv7aveb4s3Z80Oo3C0UftdCDx/R7cXWkGqFB6I5CmtpcWWcLtLfb0sIKl3HE3rfDPclqK4sM46OOi7iGAlfk9RVcWsVv6on0yZHInT2T0QCWwvS2KnwuntARJ0jmIoQf8MrrfwwuchFrqyZ3+D0pZzg3NIXLSQSoVKySAOAafTE+NIQzElT9pVJPfFkJ/1kYRUGoIuc/OlnN8QIDAQAB"
         },
-        "url": "https://raw.githubusercontent.com/easylist/EasyListHebrew/master/EasyListHebrew.txt",
-        "format": "Standard",
-        "support_url": "https://github.com/easylist/EasyListHebrew"
+        "sources": [
+            {
+                "url": "https://raw.githubusercontent.com/easylist/EasyListHebrew/master/EasyListHebrew.txt",
+                "format": "Standard",
+                "support_url": "https://github.com/easylist/EasyListHebrew"
+            }
+        ]
     },
     {
         "uuid": "AB1A661D-E946-4F29-B47F-CA3885F6A9F7",
@@ -370,9 +466,13 @@
             "component_id": "eaidcpcfnepdmmhbglgjhpjdfodkdcki",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA6srtCOWjPWh8AiCrnjcJd9iFwmhs+5VMfnfaQnK5PeK1//Hr0xlrS9S6Q7AHlE3O7fBFS9EkBGXAXPeqNpXAuE1wKkzmKkOWRT2mCWQcc07sbIUjyXaQL6UIJYTQREJEZzif+beXopscv/ALsJkbTcMWaCbqrTx7SHVlIdkf44B4VccYsp99vhDg5pzhMgDtq+f2ni3jzM0EmECyp9lJefqVEvg1FXNLI3Z0DxkYr1izYCbH3X9NNj+xs7OFz+5eXwus/Ikt9JRtYush7Kr50O7fD/ouvdB/gpCXsvqDW1F3x97ysRZwEQTgioLlVnMs4DN0T0TGoGULr7QkmpzigQIDAQAB"
         },
-        "url": "https://easylist-downloads.adblockplus.org/easylistitaly.txt",
-        "format": "Standard",
-        "support_url": "https://forums.lanik.us/viewforum.php?f=96"
+        "sources": [
+            {
+                "url": "https://easylist-downloads.adblockplus.org/easylistitaly.txt",
+                "format": "Standard",
+                "support_url": "https://forums.lanik.us/viewforum.php?f=96"
+            }
+        ]
     },
     {
         "uuid": "A0E9F361-A01F-4C0E-A52D-2977A1AD4BFB",
@@ -385,9 +485,13 @@
             "component_id": "njbfmhgmihdjfgecgfhgknkinndnojgf",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA85EG3eFmZn/VmRqgmfOzcqGNbCUIsj2ZKu/GfKG1cYz6N1Qyadmmx1slJhc3wqaSav9U15SaktcELk9d2dSXEsQPStluf2Vrw6ClqgTUmcxkjtni8PY8KRLd6ZKw1mUO29NonN7B8qEUWAiObqPP6dg25vSAoj1NXgnkq7WlA/JMZx+rijviam2Ya0HdXoUIOeuzYhNQERjH2R/Va2EDT+LsPXSjW3qGxfBabQfMuFFhjyTIvK5vRMNwoxTV1q7Z0o/zdB9HtXZlEWpkEEBiWFZo6F+4tUBopsCSICbSqbwAoJemo1O0BvR2suf+yIxuwbWMv4y36AtFBbhT4tiCqwIDAQAB"
         },
-        "url": "https://raw.githubusercontent.com/gioxx/xfiles/master/filtri.txt",
-        "format": "Standard",
-        "support_url": "https://xfiles.noads.it/"
+        "sources": [
+            {
+                "url": "https://raw.githubusercontent.com/gioxx/xfiles/master/filtri.txt",
+                "format": "Standard",
+                "support_url": "https://xfiles.noads.it/"
+            }
+        ]
     },
     {
         "uuid": "03F91310-9244-40FA-BCF6-DA31B832F34D",
@@ -400,9 +504,13 @@
             "component_id": "llgjaaddopeckcifdceaaadmemagkepi",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAquaOTeP8r+FbVSg04QHQYQGU3NxdQNsbC3+K7GtAB7p1YnrbxD3YEUKYI357Tasm7URCWTtRGXIkOIxUv4hLL8JNUNKdROaCruKPdpDNwTJshWzPfgKo/ZHTYyduUUP1w4o1CfqQRw7FpekOebbTsm62yAEPe+RXxHfyu2YQ+njCX7IPvI0or2I3i53HCWz+fxaTenpcEn38TlkwLUdlRR183v+e6kfjDvo5HgvNQJsFFC9MM++yd8KdZrDuombSyFIUTzuP43yixeMLBeZ8IbGGpC+en8CA9OgekVhsIYWRbnRGzZmspgZ2Bq/SOuIqf0fLMgwLmNbgD4h1SIbmKwIDAQAB"
         },
-        "url": "https://filters.adtidy.org/ios/filters/7.txt",
-        "format": "Standard",
-        "support_url": "https://github.com/AdguardTeam/AdguardFilters"
+        "sources": [
+            {
+                "url": "https://filters.adtidy.org/ios/filters/7.txt",
+                "format": "Standard",
+                "support_url": "https://github.com/AdguardTeam/AdguardFilters"
+            }
+        ]
     },
     {
         "uuid": "45B3ED40-C607-454F-A623-195FDD084637",
@@ -415,9 +523,13 @@
             "component_id": "gdlpebjigadbdpjpfpdbmogebilelnbh",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA32WAaxLDPB/tRWpUQmFYskJQWzqfKz+MdTQGrvHbvCE2lo8ssU5BW/61oIBENfU7NXslKICOMREIU9JA1/I/ew9bF4X1VExdqaLkzwVPmTOKwamv3VNnNXydQY0S0MwexZ6lL8Dm++/T/mmo3IDY3AMfUX51NrDmNqJk5HKsAVJMDqGh5XGuySsJk4iZOeJiqheiUB7JP7JXaWBxjh9wO1W4/wp5oxcIN9V8LSowLGzG5e5MTH4VHjWkipLd4zkwYnsEC0pK+08i0WwEUEdGVFtqKTBRt/vCpg23OqrOIRRiTZaa+tUAy1YbtNUanvr3ioreTuYwbCx04MOLss904wIDAQAB"
         },
-        "url": "https://raw.githubusercontent.com/yous/YousList/master/youslist.txt",
-        "format": "Standard",
-        "support_url": "https://github.com/yous/YousList"
+        "sources": [
+            {
+                "url": "https://raw.githubusercontent.com/yous/YousList/master/youslist.txt",
+                "format": "Standard",
+                "support_url": "https://github.com/yous/YousList"
+            }
+        ]
     },
     {
         "uuid": "51260D6E-28F8-4EEC-B76D-3046DADC27C9",
@@ -430,9 +542,13 @@
             "component_id": "iihfaghdnbilkdhmmnnkebhodfgeaopd",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsS7LwpmM6baZKPgEVYsRiLZAV6TpvdwRGAoXbprVO05/uSySDPuRvmQt/76oODglOIF3ZJcru+YJE/nCVrXApHbNR8Y+LWsbKf33Ae+Ljw3GuzYOnnIpH6hsgJYGShCWya/5np3pzLpDJgYKdg8TFdnjmf5xQ7h30xek3qAHPzT0gUfa/GKlIiTo0yyMz0qT3evxlDOtJhRK/zC30qnzQuFqMmu0g58klp4XGZ1E1l1CaY7dY3iOSYZnjEcsK3ooKwpnUGi5JICJw7bUI4RxiDX5DL72SOqS4NZSlOvX8nkMZWW/iuYkYckQD3Ya/bCOZlDaZjKoQDHAyXE0zeP5hQIDAQAB"
         },
-        "url": "https://www.fanboy.co.nz/fanboy-korean.txt",
-        "format": "Standard",
-        "support_url": "https://forums.lanik.us/"
+        "sources": [
+            {
+                "url": "https://www.fanboy.co.nz/fanboy-korean.txt",
+                "format": "Standard",
+                "support_url": "https://forums.lanik.us/"
+            }
+        ]
     },
     {
         "uuid": "4E8B1A63-DEBE-4B8B-AD78-3811C632B353",
@@ -445,9 +561,13 @@
             "component_id": "fmddkdeghohhfoglgdpkhlnfgmmffklg",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAlW+uDh7W9fxDMhekhHT+KeeAnf/I9SHZWNjpXeZ0bdhEqi8BxJ8UQFAABdKp0ZIg5mkurvx8/y3DYXrnM4z2Dd21UDmsweEVsS342RNZKtmxo9QFg/Zi50wwMcaVkGo7l3D/hPHb0Ss+M7y+E4bx9KkilUw786DPSvW1Z8jPKrx60+em/7QluU1LtkLjMXDocgG7bSvx9XV5thcCszXOGgoDVGlosD2gTVljXmtahVFUU2Hh42Iw24bQRc+PFYeqp8f08M7v7G0jmCWcehXWlnrr1wbmqCQvcLr33M9E7z3LisVoVOW+Nx6upsC8MgNDtbgHgub0ZAPm9WemZ2wfJwIDAQAB"
         },
-        "url": "https://raw.githubusercontent.com/EasyList-Lithuania/easylist_lithuania/master/easylistlithuania.txt",
-        "format": "Standard",
-        "support_url": "https://github.com/EasyList-Lithuania/easylist_lithuania"
+        "sources": [
+            {
+                "url": "https://raw.githubusercontent.com/EasyList-Lithuania/easylist_lithuania/master/easylistlithuania.txt",
+                "format": "Standard",
+                "support_url": "https://github.com/EasyList-Lithuania/easylist_lithuania"
+            }
+        ]
     },
     {
         "uuid": "15B64333-BAF9-4B77-ADC8-935433CD6F4C",
@@ -460,9 +580,13 @@
             "component_id": "hkeaopcnlcfbmbogejmbipnnopjlpiph",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzKJQ+ZqjJLJ6sBvIhxOmFV/jUJ2qIdEwTjvNd/zb5jmqiYhFTamZph1qoov3S7Ob6oFZIrluwhYP3i6koTOLFMRDpgV5m6K0xtAZyTxJn/YrEi0kqJ1DY+v9OOrtMOSZTF+Y5GkYsrG1F28KQm+pxJ9BVreGBx93Tis3CbGTGorPHbKe74IyYtWHEJ7azFhp7O7bLAMZfO3j/g7XRK4m+o2pW7pmd+YVdixQOblWK6ha6Ircowo8M/LwlQ1Z7EAmpXSUzEk4cGF6IlekyEou4SmcR+eNZcGpTc+KRNGe+gyZVkd8HuVlG4fphFQRGkNxl9/7ttZLohO5CGJQj5srVwIDAQAB"
         },
-        "url": "https://raw.githubusercontent.com/Latvian-List/adblock-latvian/master/lists/latvian-list.txt",
-        "format": "Standard",
-        "support_url": "https://github.com/Latvian-List/adblock-latvian"
+        "sources": [
+            {
+                "url": "https://raw.githubusercontent.com/Latvian-List/adblock-latvian/master/lists/latvian-list.txt",
+                "format": "Standard",
+                "support_url": "https://github.com/Latvian-List/adblock-latvian"
+            }
+        ]
     },
     {
         "uuid": "9D644676-4784-4982-B94D-C9AB19098D2A",
@@ -475,9 +599,13 @@
             "component_id": "oojedkppeblkjkcdlmlahnhndjmbicoi",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA258rAhhideU4koO8wXSn+mgxg+PBAv3+4fYEgf8ezDIOb0zXikwunPGMUCX1Z7dpyqhzYjtYFZvdPlXWJglEA4mpRpQjb5MUKALRC5oQopDhQnZlwhL5YtPYEo60yisqAEFrBm+ngdchqI/41AZuAqY0eNu6in5wxoW2norZigFMovXDWGSEOt63cpXg9KjcwN02cH26k2DO2jLLUFkjRCy6v1XKFufBMoGc6T1MB5wzonFeh1uZvJHJV/M6P+NZuRG4F6SimF365Uq11bvgLzE49tIWVXdkt5MxPzJESr/+r6M+AfGK5nt5tyWDRAW5Wrp74ae2T7p3e0grkqNeuwIDAQAB"
         },
-        "url": "https://easylist-downloads.adblockplus.org/easylistdutch.txt",
-        "format": "Standard",
-        "support_url": "https://forums.lanik.us/viewforum.php?f=100"
+        "sources": [
+            {
+                "url": "https://easylist-downloads.adblockplus.org/easylistdutch.txt",
+                "format": "Standard",
+                "support_url": "https://forums.lanik.us/viewforum.php?f=100"
+            }
+        ]
     },
     {
         "uuid": "8BEDBAA8-4FE2-4FEA-82F2-81B8124A4A74",
@@ -490,9 +618,13 @@
             "component_id": "kjdbffhfijkonelaglifggkchhmgmeli",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAr4vfQONxziLBVdFe1dHEjn5Ut+TcO62xyF0yfF9MVZqnOq00SNzyhUbXyzU6HxSzLU/eMkmTeIBJ3h+f4f3TPirs6s+EtqJkZ8R4er5aHhexGLKUt3uhkLv1IYYw9JimsfxMQOKWtz1O2MmbJJ5HcQ1jQQ613x6SOWtPpkeH0FdcwSiV83DJMVUjVFNwBdl2zjqulQP1M6geNt6eSNN++p2oB+K5kfpMAPopRuRfhZ1spDSm65qfBGGYfgPl6FanfFpTMm/U/vC76KeoMW/xpQw3s1TQeQDY3QywBWasUxmxiJN0DRsVapCAFqT0dXQ+Q3GCCCGPSB1+EUusnSJpgQIDAQAB"
         },
-        "url": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/NorwegianList.txt",
-        "format": "Standard",
-        "support_url": "https://github.com/DandelionSprout/adfilt/issues"
+        "sources": [
+            {
+                "url": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/NorwegianList.txt",
+                "format": "Standard",
+                "support_url": "https://github.com/DandelionSprout/adfilt/issues"
+            }
+        ]
     },
     {
         "uuid": "BF9234EB-4CB7-4CED-9FCB-F1FD31B0666C",
@@ -505,9 +637,13 @@
             "component_id": "ngcohbdfildjnmfnicgdipopmlhdcokg",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzI7s+FWv8M/Nr+OdXIooICxtv+Q1TS/gpN32+ToVeFHuaQwWZ+O+aN95D9ZRrRb1/mQQW6EkY9Ce5LxUjosw0C9bF0yyB5AEZ+lJQIelrY2c9AvEK8wcNiI/T0GTEcpB0KnOI0tMhfVZZnUj3piiqUZHvXKvcuA6bPoaalPy260o7npU53UZjtMf8RGEigECWqaEMLqYRq4j7xhX8Y8lMeqGfw9Ff3jC2LUSZamTHL2lSdCzrlYN4LMHnAIawR3HSll295BEwo+OBj5vjD4JpZ7NxapUPnXw8k/CGfsKPomQwuBb/JWEGBsgaw+5EFPVKz69MoqR90p6hdZptQZJYQIDAQAB"
         },
-        "url": "https://raw.githubusercontent.com/MajkiIT/polish-ads-filter/master/polish-adblock-filters/adblock.txt",
-        "format": "Standard",
-        "support_url": "https://github.com/MajkiIT/polish-ads-filter/issues"
+        "sources": [
+            {
+                "url": "https://raw.githubusercontent.com/MajkiIT/polish-ads-filter/master/polish-adblock-filters/adblock.txt",
+                "format": "Standard",
+                "support_url": "https://github.com/MajkiIT/polish-ads-filter/issues"
+            }
+        ]
     },
     {
         "uuid": "867EF333-8336-455C-9CC6-98749AEE69E4",
@@ -520,9 +656,13 @@
             "component_id": "beeceepafhbchnbfdkfalfipoancnjkm",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuvdYUaLF2iI9loRQjDLZelATqaMso9wPX0sBZR1i9MrqM5pw3o5x9sc57SYiuCQJMKwD8l8g4S7WEHyfGs43EYmiO0/1LE2QJ7765x3tyN4LrH+PIGvrVdFkdeVv23uQ1Vk9kZ9OiCo5+ZvpGIavWFGQ7Cq+QJAu3omKLzHQUpfph8UgRlEGjJo0g07Dc/4vsNE8qF9LRTpThxlMZIvWU4ZPsd/bW4VBipvAMDyMvUBwA1gW/3ehPY4rekuykK7RGcsX9hCoLn0Nm3J9/tHfYk0vS76yNcaYq1saITBlBzqPnrwAc73sQjpMkwfWgdrPl0JsQJ9lRlzeoecyOcmkEQIDAQAB"
         },
-        "url": "https://raw.githubusercontent.com/olegwukr/polish-privacy-filters/master/anti-adblock.txt",
-        "format": "Standard",
-        "support_url": "https://github.com/olegwukr/polish-privacy-filters/issues"
+        "sources": [
+            {
+                "url": "https://raw.githubusercontent.com/olegwukr/polish-privacy-filters/master/anti-adblock.txt",
+                "format": "Standard",
+                "support_url": "https://github.com/olegwukr/polish-privacy-filters/issues"
+            }
+        ]
     },
     {
         "uuid": "CB3A9B4A-C9F3-40FA-A6B8-5219ED5FA9ED",
@@ -535,9 +675,13 @@
             "component_id": "bdnfonbomiianhopbpfgfeekmlcbegfo",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA77Cpl7pDmqWRY8sjZhvJ+GxIHDmA7PvUZinQz0PoOz3wEuWmuFU6mOOx6uUi83onGMamcu5ofHWAZBNYRIXbbPcpC4a87YLbpfTegKi7TX9BTFrUMUZCKlO74z6LZO8R1APLAcse6rubCkpyyuvMZ4mcbCA+vKv8RPh4YLhSRWhIi/UvueiaTOew4QkAq2W2q1FtStK9w5uBtBJBFX8LR456AMKZ554bpZ9jea9/8kasXvrbujwyx6G1KueQW1QIUlXbVVxGs+fKMMj3UYxIODYQUqXkV1YvWmdZ3jNApnnOyeJJNEAfNlMw/KMJM2m+S9apXqOdR7VhE5SCZ99wlQIDAQAB"
         },
-        "url": "https://raw.githubusercontent.com/olegwukr/polish-privacy-filters/master/anti-adblock-suplement.txt",
-        "format": "Standard",
-        "support_url": "https://github.com/olegwukr/polish-privacy-filters/issues"
+        "sources": [
+            {
+                "url": "https://raw.githubusercontent.com/olegwukr/polish-privacy-filters/master/anti-adblock-suplement.txt",
+                "format": "Standard",
+                "support_url": "https://github.com/olegwukr/polish-privacy-filters/issues"
+            }
+        ]
     },
     {
         "uuid": "AD3E8454-F376-11E8-8EB2-F2801F1B9FD1",
@@ -550,9 +694,13 @@
             "component_id": "cgmhmpbimmakidhlkcnnehhicoclofep",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsPK8KQaEM2wDchLR8GfV40qmWdwi2QPpKhBq62Tihw7gmFjKNIQN26fHB+NDn8H/GC5XCmZD2uAMrRvcfR043imLWnCmBU5cHtPoQNAN/VWeffzOMaNn5JIMlpwtFZDfISXAaDiNMPLY1uEEVuVwqoX4bA/U6VfCnkIQcQwGJO58AH50Dk0Deq2xgUWmFpJgCMwGcp0Hv1OEERcVhtmpoaetVtfkUmBsOd0CwcSdT4p9zMXWRuHGmgbMayBXL63hksmnNUBYcyzUqxSDwA4OqaLaNZovLc3CMgVXQ55n3wpo+HmMDhr4OLWULgXsZDne5wehZS6QOaR0G+bqOmev7QIDAQAB"
         },
-        "url": "https://raw.githubusercontent.com/tcptomato/ROad-Block/master/road-block-filters-light.txt",
-        "format": "Standard",
-        "support_url": "https://github.com/tcptomato/ROad-Block"
+        "sources": [
+            {
+                "url": "https://raw.githubusercontent.com/tcptomato/ROad-Block/master/road-block-filters-light.txt",
+                "format": "Standard",
+                "support_url": "https://github.com/tcptomato/ROad-Block"
+            }
+        ]
     },
     {
         "uuid": "80470EEC-970F-4F2C-BF6B-4810520C72E6",
@@ -565,9 +713,13 @@
             "component_id": "phmomndefejccjmpiehbogokakkmnmgb",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtUdVZS1RGK6o+gfhEu1d8o061nYg/QCvHhojbyt09I3H+sc3lIr1cpK37msXq+DaFQ1LHbNk+9wTDfe7IIpvMFGSWx27P0T0mh63qjuFzfP5dSIDWhlCgPl8bUbHkf3e1bbNC1TAlGQDjZdxz7t/qDfslICWXLcKVz/1BtT/kG1PPrXjRq+NKBEqqV841RAIXnH4/LcfNLVCTs6EFvqRva4aN1DHuZdejLAMAbgR6JH0cMJ9RBO/5/ebZUL6C0XFjobgdj/2Rh+GYSrxL3jDql7jheKOrTbpJx81z3iUNwghrlHD56BbFs0eC3ZOAYHbIdYBkFIUPwpL78v5xyA94QIDAQAB"
         },
-        "url": "https://easylist-downloads.adblockplus.org/advblock.txt",
-        "format": "Standard",
-        "support_url": "https://forums.lanik.us/viewforum.php?f=102"
+        "sources": [
+            {
+                "url": "https://easylist-downloads.adblockplus.org/advblock.txt",
+                "format": "Standard",
+                "support_url": "https://forums.lanik.us/viewforum.php?f=102"
+            }
+        ]
     },
     {
         "uuid": "1088D292-2369-4D40-9BDF-C7DC03C05966",
@@ -580,9 +732,13 @@
             "component_id": "jiajbjlakknofnkmlokcbanjbajpbdkl",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvmC+nOMvt+lDivZj50XLbNPrcye4W7en/zP+CqvSVZ+MLwcH6oOF/YtLqzVMl05JOAutllDiO0Kwme8E/EpJI5Tw/JIYTLSzm2t3hDbWMo7EB8WobkIp9vXIKjEsRaw/QQR0b6BoqclyunfCutQfM+dADwJStJypwQkUuZPV0Xgl8M9uPDO4srAcrAs5Afc4wIDRxgGL+yWlp/XE0eUrJk37pZY9invINbTlFUoN1g2C3fWaRZ+kuH7AtlHhucKLTHtQIYD/eh3bmq2+0eLcgC6dP87PhSADTujuUIHMG4QivBz8a9o4lmcvZLztjsf5eQDh8+D4En69/IMrpKM9mQIDAQAB"
         },
-        "url": "https://adguard.com/en/filter-rules.html?id=1",
-        "format": "Standard",
-        "support_url": "https://forum.adguard.com/forumdisplay.php?69-%D0%A4%D0%B8%D0%BB%D1%8C%D1%82%D1%80%D1%8B-Adguard"
+        "sources": [
+            {
+                "url": "https://adguard.com/en/filter-rules.html?id=1",
+                "format": "Standard",
+                "support_url": "https://forum.adguard.com/forumdisplay.php?69-%D0%A4%D0%B8%D0%BB%D1%8C%D1%82%D1%80%D1%8B-Adguard"
+            }
+        ]
     },
     {
         "uuid": "DABC6490-70E5-46DD-8BE2-358FB9A37C85",
@@ -595,9 +751,13 @@
             "component_id": "iiglahilpgmhlcogkkihklnbcjjgpddl",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAypc9kkULwkl0+NmhXX7MZNsoF/G3QaMJ/sYa468w7rhQzJ8PMkfeGeYtMQnvpLh3pALw4Y0gAlTwWaK21BZWdrsAyjk4IM+gTsztSrK7ffflw4usQSlOI0MJpJ1lj9pKCSeux0Pr0P+mGFWMDIxDyefBbUkMzM1JmsVXsDHVpoHikepAKkBKwW0F8Uzv0jFa1M5BxRK5n9nLOxTA3gCmcxUjeLMAYtQvzGf5pg/YwHz64J+snbwEJo8Lo9dUcpLk9ZoNuMqgoVa7UV4FgXCYhT3c3/cyK6673gy33WW5I+0tu9qTpY263StQ1hUWx2LnylJ4qbI8kKqotiGJy2JoLwIDAQAB"
         },
-        "url": "https://easylist-downloads.adblockplus.org/bitblock.txt",
-        "format": "Standard",
-        "support_url": "https://forums.lanik.us/viewforum.php?f=102"
+        "sources": [
+            {
+                "url": "https://easylist-downloads.adblockplus.org/bitblock.txt",
+                "format": "Standard",
+                "support_url": "https://forums.lanik.us/viewforum.php?f=102"
+            }
+        ]
     },
     {
         "uuid": "AE657374-1851-4DC4-892B-9212B13B15A7",
@@ -610,9 +770,13 @@
             "component_id": "fejmaeodjeekfldnbegjagemjgnmhfof",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAv7yIqlQQ/fK5DkO90mULt6tdYXm4sdROKgLMd9PGxuXkTMWt2gI2VgnOIMKXenr6yQ35kx859rr7dcV8bOUPPCVZsu3zU3mxJoPt6+wOZH00na1n6XVS/jHFULOeqKA7fj/2GYyTvdaSpLL2B7u/limqbZ/IQSBoc0GdEfsjEghKFvFhWmZw6g0UAp0ZiJzm13t+ta2FjCDTfrnXJFt1VY/hd4Ip2i4KmBKByR0gfv4ksqY0rSVJhXjcbrXHqBZvRUr/vw6bBmnFVCJlQKS44S/5QLDsmxm2E2kIp2LmSMLjoYPqTZnthCX9/svwCp08LRwvDHtVSS3c5MsgRzwMkwIDAQAB"
         },
-        "url": "https://easylist-downloads.adblockplus.org/easylistspanish.txt",
-        "format": "Standard",
-        "support_url": "https://forums.lanik.us/viewforum.php?f=103"
+        "sources": [
+            {
+                "url": "https://easylist-downloads.adblockplus.org/easylistspanish.txt",
+                "format": "Standard",
+                "support_url": "https://forums.lanik.us/viewforum.php?f=103"
+            }
+        ]
     },
     {
         "uuid": "1FEAF960-F377-11E8-8EB2-F2801F1B9FD1",
@@ -625,9 +789,13 @@
             "component_id": "meimhmgfbckapkbbbdaoefgnbppmkodp",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvZOGZijGxkLbvTxJY/4nih6wdCBI7zJLrUwOUMXsv9DOVRJvh8s5CHYRQDwxUhNbWGOubxyjYT8Je2sb/5fLFJXqBFbC+xZQbRAshfpOJjO+ZJC6EAUz+MsG/xWqQZfHHuJ71yLSaSt55dFSvZiF7XqIPIrT3enTdILCgT6Ql42faE6d3EBcQm/lR1fyuBS8PGfcjiIL6rIvcNiTSvU2530m/x8ie2rWijMxJp+JlHejMzc3OJ3Z7Lz+52u/WFWMeTbVNDK4LQ1OEwTPxsARd13UTkk9S0Kf4B6G3OdND3lpzso3CPF3z52i22SUqOJE4nudWKWqkXVoDVNJGebnCwIDAQAB"
         },
-        "url": "https://filters.adtidy.org/extension/ublock/filters/9.txt",
-        "format": "Standard",
-        "support_url": "https://github.com/AdguardTeam/AdguardFilters#adguard-filters"
+        "sources": [
+            {
+                "url": "https://filters.adtidy.org/extension/ublock/filters/9.txt",
+                "format": "Standard",
+                "support_url": "https://github.com/AdguardTeam/AdguardFilters#adguard-filters"
+            }
+        ]
     },
     {
         "uuid": "418D293D-72A8-4A28-8718-A1EE40A45AAF",
@@ -640,9 +808,13 @@
             "component_id": "nnpbcdahaefknppiijdmnckpdgojejck",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArD9/YNDpxamPQ937PVUqokLSeHB7pZCsRR46lEwLgD9FEQfNFd8Ji0K3irclaF6B0/3H8dvJbp3hjCOfGONWKmM7GpihipzBYEtdd1ueXDhnSoxNV/T87/x+RzaiTM2oznaAp+7jw+TfMkDyKYh3cFQMROTxTcE3rs4Ocs/mhBsFbumU42GRpQUSLB9f4L4KhLo6SGby2FYSSHspo46m6xJ63sGnQPLyiuH4hOF00b/XEQUUH6MYCg2WL51LZuVgFkcHWSBK/8HihZOn2ndAr2e2MEtqH7tmQMwQmVqouX4WITlbJ0XnrNUs0o8IYbOUmtp0SWTJtPHpYDeot5DXAwIDAQAB"
         },
-        "url": "https://raw.githubusercontent.com/betterwebleon/slovenian-list/master/filters.txt",
-        "format": "Standard",
-        "support_url": "https://github.com/betterwebleon/slovenian-list"
+        "sources": [
+            {
+                "url": "https://raw.githubusercontent.com/betterwebleon/slovenian-list/master/filters.txt",
+                "format": "Standard",
+                "support_url": "https://github.com/betterwebleon/slovenian-list"
+            }
+        ]
     },
     {
         "uuid": "7DC2AC80-5BBC-49B8-B473-A31A1145CAC1",
@@ -655,9 +827,13 @@
             "component_id": "ggjlfgjhaeedkajcdpomeidjlniafdnp",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtMkbz7fkdzW7Gh+/F9yhFSSNRpWYe1FRYEkVPxClGGL7yta9cwmskmDqskAHaIP5JRQuvgJ71cSUgBWtUmDyhB4Cl5ZE6VSpe88xJxcrOctpwewwqbpwZB2/8PMkQFPXkjLoc1VvYXHRdjXVZumQq0wq3xnWNcp+o7WHebgciZIEBaXWyvg7Ire156qx0ru4AnxAkccKrv/iHCaKy7dcaEj7Npw85/s0zhLIK4jfwdYRe3/U1Tpilgq6R6JQ1rsN0eCi7aGuam9p7v5JZH8823NZ97jkURAJDJTfvY7U8auca1pSiBSzPBIrfkNXN6D0lRcLdO6Bm6cs52JbxYo4MwIDAQAB"
         },
-        "url": "https://raw.githubusercontent.com/lassekongo83/Frellwits-filter-lists/master/Frellwits-Swedish-Filter.txt",
-        "format": "Standard",
-        "support_url": "https://github.com/lassekongo83/Frellwits-filter-lists"
+        "sources": [
+            {
+                "url": "https://raw.githubusercontent.com/lassekongo83/Frellwits-filter-lists/master/Frellwits-Swedish-Filter.txt",
+                "format": "Standard",
+                "support_url": "https://github.com/lassekongo83/Frellwits-filter-lists"
+            }
+        ]
     },
     {
         "uuid": "658F092A-F377-11E8-8EB2-F2801F1B9FD1",
@@ -670,9 +846,13 @@
             "component_id": "johkmlmpfakcaopiapbmcocgpkabdmed",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA5ndE+g/8K+nvdkIEct4mtVFQpexmeklQqtbBstIw2hI5aF+HAvgtMk5RTn0qicwGku1kCJEn0TDP8IbAMhgcODc3BzCmPwnE/oHJ9EvO56+doo8SL5SJaQ1ws2Os1lOZeatnKWr07SaCL39M/Ychvj3yccDVer7T339XmZ/TvkaKMlrKoFYGJzoGPjoBS7vw2SvsFWHCgsVEtpbGEXZD029z1YaNDGPBPvnuk30Ir9sPw4uurqTZxR9RKquJB/QBm3l/eT3UICED30yFthpP+8DVLpH6J5lKM9EqD8df4VyiSjotYAqNNJKgTNWOzQeFud/t26sQgyXGVUBBT2VNEwIDAQAB"
         },
-        "url": "https://raw.githubusercontent.com/easylist-thailand/easylist-thailand/master/subscription/easylist-thailand.txt",
-        "format": "Standard",
-        "support_url": "https://github.com/easylist-thailand/easylist-thailand"
+        "sources": [
+            {
+                "url": "https://raw.githubusercontent.com/easylist-thailand/easylist-thailand/master/subscription/easylist-thailand.txt",
+                "format": "Standard",
+                "support_url": "https://github.com/easylist-thailand/easylist-thailand"
+            }
+        ]
     },
     {
         "uuid": "1BE19EFD-9191-4560-878E-30ECA72B5B3C",
@@ -685,9 +865,13 @@
             "component_id": "gomenlogbembmkbghmaoledggliepdef",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2l4J/f1wAJESK4G74P/2aZMsK+r8oUGB2QIN3Ny5tFxONihjidt9wgmjXQvsR5AYhLamylmH3u9u8mo6NC4b0qVE6imybPgp9/Z826O4VOCBd3yVxe6TCf76tuLSRfUjzreqt3Q6ly0JxgaoKXTWOnu3aoQyg/MnBmZ+REpKcE6W0Pyts1/yGDWs4S37tS2uCEmd2Wi4pUWfmzDE/RtTbhNNxoLoa6GczoeSXZww5emW2LahpE6Y8wGz/mPwjbUn0//T2y4Uqn1/HfMANEF8/t8ykk7cWXB3HdA8abg2Vib+dweCIiV2ZDFcx0l0j/SGCIDKwQYWZZkfF3P7Hp/RwwIDAQAB"
         },
-        "url": "https://filters.adtidy.org/extension/ublock/filters/13.txt",
-        "format": "Standard",
-        "support_url": "https://forum.adguard.com/forumdisplay.php?51-Filter-Rules"
+        "sources": [
+            {
+                "url": "https://filters.adtidy.org/extension/ublock/filters/13.txt",
+                "format": "Standard",
+                "support_url": "https://forum.adguard.com/forumdisplay.php?51-Filter-Rules"
+            }
+        ]
     },
     {
         "uuid": "6A0209AC-9869-4FD6-A9DF-039B4200D52C",
@@ -700,9 +884,13 @@
             "component_id": "ooamlicohiiaodkaemgoimcihidbedmp",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3NaOxndIgpo142VxPI2iWEKwvfFbKsQpxZeGzLGbhO7SwFi7AcEBvDOS6Ufc2PQ3Cz7+TxvUO8a4uEVK/SEiNtMhfL7LGlfMyxV17hIJEjWN1ytEEAALjXJFyVkcz0pAhPC0RY/ti378dSLYL9HetA4XfeO0aC7l23dirQMZMRPfSFvzaZtrp2t35PbQCuMqDW9jbPtdwSSswa7wVYFdafaT48WDuMxxKrggWikMBDxE9/Jihd7179Bd0pmlVreBsWhj+LjLUkf+j4UksUiyttKgQ3+5ZyV5k/tzmhN2HaJC9/q+hvboBz1giOcpSb7u4PbmA82o1K62nKS5c77nTwIDAQAB"
         },
-        "url": "https://raw.githubusercontent.com/abpvn/abpvn/master/filter/abpvn_ublock.txt",
-        "format": "Standard",
-        "support_url": "https://abpvn.com/"
+        "sources": [
+            {
+                "url": "https://raw.githubusercontent.com/abpvn/abpvn/master/filter/abpvn_ublock.txt",
+                "format": "Standard",
+                "support_url": "https://abpvn.com/"
+            }
+        ]
     },
     {
         "uuid": "319A754E-065A-465F-B09D-3F2C7BF1E67B",
@@ -715,9 +903,13 @@
             "component_id": "pnoagbonokhdnppohfeemefhjbbofplk",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0BMvGe5WudkwwjswOQ61mbs6L/NNWKQK3kyw10Ew2oRWR5Jggr9IRFc3nT7tIvYZ0l/6tbOzoqM07Z3AW7ASK+am8TL3gw4nxZuduCdEJreJdlTKHxa7/Q0eYyNrTzVyu2zsiSZUFMtrWEhPdptnE15pA4NW7cy2rOWkTyG+nLZzDP1JEov3ZHia42B9RorQLN60dLLhYZl0E073FCra3Tv3wyNwnzvVskcPC9ljRSxH34UYCkjvZH8yHSZE9e/Oda2Tza3HxTy2Dm3Iu1PpfjJBYJCd76ZChlf0Pwb4hvE4YjmZd2EGXNnSpVjUrKDpSSaBORbURkm8tRXFRCs66QIDAQAB"
         },
-        "url": "https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/annoyances.txt",
-        "format": "Standard",
-        "support_url": "https://github.com/uBlockOrigin/uAssets"
+        "sources": [
+            {
+                "url": "https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/annoyances.txt",
+                "format": "Standard",
+                "support_url": "https://github.com/uBlockOrigin/uAssets"
+            }
+        ]
     },
     {
         "uuid": "BD308B90-D3BB-4041-9114-22E096B0BA77",
@@ -730,9 +922,13 @@
             "component_id": "cpapfkpkeaajehipopnaiihfmbfbnkdp",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA11xzFtkVM4xI3AeJ281iUJUmDGSjWXdNDJkP0Mv7LNdc1fa8hQuc/gOKdU9S6UjxA3HEpHMucIFKMcQZ07A9MUjiP+B/fwxrTrfwqFKyePQkrd05HjhwDgzmfBpCgx9nQjDubEamzsb0yUKj+gL3D13f4tBi7pb5GHhGAY3smwZP0Dp+ydO5ec9fs1AdgLX6kK/mTuCr+oMf9ZOkTp8KxMS6MyN/NhsMG4Jis+mOuRdoBzvF7y7p/BUm3ewVJZ2KtMz2W6/v966kpaPX+PDdKK2qdGcIClq1nFgKB8dcjorPq6xjJhvflwAtXqYXfMD2h/7Pkdz6aHZc8NmVAg4R7wIDAQAB"
         },
-        "url": "https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/yt-distracting.txt",
-        "format": "Standard",
-        "support_url": "https://github.com/brave/adblock-lists"
+        "sources": [
+            {
+                "url": "https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/yt-distracting.txt",
+                "format": "Standard",
+                "support_url": "https://github.com/brave/adblock-lists"
+            }
+        ]
     },
     {
         "uuid": "2D57ADED-3531-419A-9DED-7F8868BC1561",
@@ -745,9 +941,13 @@
             "component_id": "phdmgpanpejkbmbljlhcehpadabljfbk",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAv1vkW0NQdDtdNQt/BZ9M803R3dHx3ow0XN3rCh4vo9lXpiJot7RIxTSo2qKUWHype4g0MCL/NIiFq6jY0rdBpCP5hv6GmFf6r8uZsurWA/FVH7hzY1tcJ1t5zBZUufamlWQjeUdCkflsrP6p07JK3SR1WFi8xcTT2uQ8Yrkb6ioq5C1mBOljbVPJuYzk99acKu55lvWG2uKH9aDuHd0OuK8+CJycWVDdeFoGXuGHlTfURDbmgnv2P23jctE0viEH+vuk5ecofhmBG0rXpbF/fqJJYQu6DINIyc4E9NQ8W2ryutTBo7r9ZbW68uiAe+7UVrMkFagjl66xK0WXNcGBlwIDAQAB"
         },
-        "url": "https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/yt-recommended.txt",
-        "format": "Standard",
-        "support_url": "https://github.com/brave/adblock-lists"
+        "sources": [
+            {
+                "url": "https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/yt-recommended.txt",
+                "format": "Standard",
+                "support_url": "https://github.com/brave/adblock-lists"
+            }
+        ]
      },
      {
         "uuid": "78672887-A098-4D2C-B0CB-A3DEC4834DA7",
@@ -760,8 +960,12 @@
             "component_id": "mjhbdghipcamfoojbeikdojibeelbmil",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4p2Fx/w0R4RVscwM1bobz4jcc40AkE+Ccp9azcUreKZWa3I75hv4G9MQOp9xHvxXVxcIVqRiGDdSyyDHCe+YMbYMQJhGdTEItPx5c3IZ/Lq35gJXLBb5+dqW+g5lp9I8+19YN5GLnkVU2snMosJ+ie6rkQaE2zoFOiPf7Uiode5FroCsgDh+OZpOeXkbbOWUBgNY3zaAZ9PY00k4R327Qk01LUfhokfgZxcvxOofIuIR992q5xxPreMHat2ZBDbEuLAuNda6/cJqhn6M4cCyHJh4+bv9GjcBGtd/QGiXD/s48fPfm453wYjd+DAtmLwBjQOsw4gcPmt5gTui6eAkOQIDAQAB"
          },
-        "url": "https://gitlab.com/magnolia1234/bypass-paywalls-clean-filters/-/raw/main/bpc-paywall-filter.txt",
-        "format": "Standard",
-        "support_url": "https://gitlab.com/magnolia1234/bypass-paywalls-clean-filters"
+        "sources": [
+            {
+                "url": "https://gitlab.com/magnolia1234/bypass-paywalls-clean-filters/-/raw/main/bpc-paywall-filter.txt",
+                "format": "Standard",
+                "support_url": "https://gitlab.com/magnolia1234/bypass-paywalls-clean-filters"
+            }
+        ]
     }
 ]

--- a/verify.js
+++ b/verify.js
@@ -20,40 +20,41 @@ tap.test('resources are parsed OK by adblock-rust', childTest => {
     childTest.end()
 })
 
-tap.test('default filter lists are correctly formatted', childTest => {
-    defaultLists.forEach(list => {
-        tap.ok(list.url !== undefined && typeof list.url === 'string')
+const testLists = (lists) => {
+    lists.forEach(list => {
+        tap.ok(list.uuid !== undefined && typeof list.uuid === 'string')
+        tap.ok(list.uuid.length === 36 || list.uuid.length === 37 || list.uuid === 'default', 'length mismatch for ' + list.uuid)
         tap.ok(list.title !== undefined && typeof list.title === 'string')
-        let supportedFormat = false
-        for (const format in FilterFormat) {
-            if (list.format === FilterFormat[format]) {
-                supportedFormat = true
+        tap.ok(list.desc !== undefined && typeof list.desc === 'string')
+        tap.ok(list.langs !== undefined && Array.isArray(list.langs))
+        list.langs.forEach(lang => tap.ok(typeof lang === 'string'))
+        tap.ok(list.component_id !== undefined && typeof list.component_id === 'string')
+        tap.ok(list.base64_public_key !== undefined && typeof list.base64_public_key === 'string')
+        tap.ok(list.list_text_component !== undefined && typeof list.list_text_component === 'object')
+        tap.ok(list.list_text_component.component_id !== undefined && typeof list.list_text_component.component_id === 'string')
+        tap.ok(list.list_text_component.base64_public_key !== undefined && typeof list.list_text_component.base64_public_key === 'string')
+
+        tap.ok(list.sources !== undefined && Array.isArray(list.sources))
+        for (const source of list.sources) {
+            tap.ok(source.url !== undefined && typeof source.url === 'string')
+            let supportedFormat = false
+            for (const format in FilterFormat) {
+                if (source.format === FilterFormat[format]) {
+                    supportedFormat = true
+                }
             }
+            tap.ok(supportedFormat)
+            tap.ok(source.support_url !== undefined && typeof source.support_url === 'string')
         }
-        tap.ok(supportedFormat)
-        tap.ok(list.support_url !== undefined && typeof list.support_url === 'string')
     })
+}
+
+tap.test('default filter lists are correctly formatted', childTest => {
+    testLists(defaultLists)
     childTest.end()
 })
 
-tap.test('regional filter lists are parsed OK by adblock-rust', childTest => {
-    regionalLists.forEach(list => {
-        tap.ok(list.uuid !== undefined && typeof list.uuid === 'string')
-        tap.ok(list.url !== undefined && typeof list.url === 'string')
-        tap.ok(list.title !== undefined && typeof list.title === 'string')
-        let supportedFormat = false
-        for (const format in FilterFormat) {
-            if (list.format === FilterFormat[format]) {
-                supportedFormat = true
-            }
-        }
-        tap.ok(supportedFormat)
-        tap.ok(list.langs !== undefined && Array.isArray(list.langs))
-        list.langs.forEach(lang => tap.ok(typeof lang === 'string'))
-        tap.ok(list.support_url !== undefined && typeof list.support_url === 'string')
-        tap.ok(list.component_id !== undefined && typeof list.component_id === 'string')
-        tap.ok(list.base64_public_key !== undefined && typeof list.base64_public_key === 'string')
-        tap.ok(list.desc !== undefined && typeof list.desc === 'string')
-    })
+tap.test('regional filter lists are correctly formatted', childTest => {
+    testLists(regionalLists)
     childTest.end()
 })


### PR DESCRIPTION
This will be a breaking change, although it should help us to remove duplicated logic across several repos, and will allow us to bundle multiple list sources in each regional component going forwards.

To summarize the changes:
- `title`, `url`, and `support_url` are moved into individual objects within a `sources` list for each component
- The default list now has its component information defined in the same file, rather than hardcoded in other repos which depend on it
- `sources` is a list so it can now support multiple list sources bundled into the same component
- `default.json` and `regional.json` now share the exact same structure

## Code that depends on these files:

### [adblock-resources](https://github.com/brave/adblock-resources)

Tests in this repo were updated in this PR.

### [brave-core-crx-packager](https://github.com/brave/brave-core-crx-packager)

Needs to be updated to pull potentially multiple URLs into each list. There are multiple codepaths dedicated to building the default component and the regional components, which can be deduplicated.

#### TODO

- [x] link to the corresponding brave-core-crx-packager PR https://github.com/brave/brave-core-crx-packager/pull/603

### [brave-core](https://github.com/brave/brave-core)

`regional_catalog.json`, which is shipped directly from `filter_lists/regional.json` in a component, gets parsed into a vector of `FilterListCatalogEntry` structs by Chromium's `JSONValueConverter`.

According to the [comment documentation](https://source.chromium.org/chromium/chromium/src/+/main:base/json/json_value_converter.h;l=52?q=jsonvalueconverter&ss=chromium):

> ```cpp
> // Convert() returns false when it fails.  Here "fail" means that the value is
> // structurally different from expected, such like a string value appears
> // for an int field.  Do not report failures for missing fields.
> // Also note that Convert() will modify the passed |message| even when it
> // fails for performance reason.
> ```

...it appears that the removal of `url` and `support_url` from the top-level filter list object should not cause any issues here, as per `Do not report failures for missing fields`. Those fields are defined in the parsed struct, but not used in the browser.

#### TODO

- [x] verify that brave-core works with the new regional.json format

~If for some reason it doesn't work, we can have brave-core-crx-packager repackage it with the problematic fields added back, then update brave-core to migrate to a new component with the newer format.~

### [brave-ios](https://github.com/brave/brave-ios)

`brave-ios` uses the same code as `brave-core` to download the regional catalog component and parse the fields. It also doesn't use the `url` or `support_url` fields. If `brave-core` works, then `brave-ios` should work too.

### [slim-list-lambda](https://github.com/brave/slim-list-lambda)

The `assemble.js` script references the regional catalog from this repo and needs to be updated to handle potentially multiple URLs.

#### TODO

- [x] link to the corresponding slim-list-lambda PR: https://github.com/brave/slim-list-lambda/pull/76

### [adblock-rust](https://github.com/brave/adblock-rust)

`tests/live.rs` uses `regional.json`. It's lower priority, but this should also be updated to work with the newer format.

#### TODO

- [x] link to the corresponding adblock-rust PR: https://github.com/brave/adblock-rust/pull/286