### PR TITLE
Break Brave-specific filters into separate source for EasyList-Cookie

### DIFF
--- a/filter_lists/regional.json
+++ b/filter_lists/regional.json
@@ -184,8 +184,15 @@
         "sources": [
             {
                 "url": "https://secure.fanboy.co.nz/fanboy-cookiemonster_ubo.txt",
+                "title": "EasyList-Cookie",
                 "format": "Standard",
                 "support_url": "https://forums.lanik.us/"
+            },
+            {
+                "url": "https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/brave-cookie-specific.txt",
+                "title": "Brave additions to EasyList-Cookie",
+                "format": "Standard",
+                "support_url": "https://github.com/brave/adblock-lists"
             }
         ]
     },


### PR DESCRIPTION
This should allow us to support the `brave-set-cookie` scriptlet.