### PR TITLE
Add Brave first-party list

### DIFF
--- a/filter_lists/default.json
+++ b/filter_lists/default.json
@@ -114,6 +114,12 @@
                 "support_url": "https://github.com/brave/adblock-lists"
             },
             {
+                "url": "https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/brave-firstparty.txt",
+                "title": "Brave Firstparty",
+                "format": "Standard",
+                "support_url": "https://github.com/brave/adblock-lists"
+            },
+            {
                 "url": "https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/brave-android-specific.txt",
                 "title": "Brave Android-Specific Rules",
                 "format": "Standard",


### PR DESCRIPTION
To merge the current standard shields fixes implement in Unbreak, easier to manage if we get this into another list.

Specifically moving https://github.com/brave/adblock-lists/blob/master/brave-unbreak.txt#L801