### PR TITLE
Fix uBO annoyances

### DIFF
--- a/filter_lists/regional.json
+++ b/filter_lists/regional.json
@@ -133,7 +133,7 @@
         },
         "sources": [
             {
-                "url": "https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/annoyances.txt",
+                "url": "https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/annoyances-others.txt",
                 "format": "Standard",
                 "support_url": "https://github.com/uBlockOrigin/uAssets"
             }


### PR DESCRIPTION
uBO is now using https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/annoyances-others.txt, we should use this.