### PR TITLE
Add CNAME blocks in standard shields

### DIFF
--- a/filter_lists/default.json
+++ b/filter_lists/default.json
@@ -144,6 +144,12 @@
                 "title": "Brave First-Party Specific Filters",
                 "format": "Standard",
                 "support_url": "https://github.com/brave/adblock-lists"
+            },
+            {
+                "url": "https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/brave-firstparty-cname.txt",
+                "title": "Brave First-Party CNAME Specific Filters",
+                "format": "Standard",
+                "support_url": "https://github.com/brave/adblock-lists"
             }
         ]
     }


### PR DESCRIPTION
Add CNAME filters to standard shields. 

Resync'd with CNAME list with Easyprivacy: https://github.com/brave/adblock-lists/pull/1259