### PR TITLE
Add Russion uBO fixes to RUS Adlist

### DIFF
--- a/filter_lists/regional.json
+++ b/filter_lists/regional.json
@@ -795,6 +795,11 @@
                 "url": "https://easylist-downloads.adblockplus.org/advblock.txt",
                 "format": "Standard",
                 "support_url": "https://forums.lanik.us/viewforum.php?f=102"
+            },
+            {
+                "url": "https://raw.githubusercontent.com/easylist/ruadlist/master/js-fixes-experimental.txt",
+                "format": "Standard",
+                "support_url": "https://forums.lanik.us/viewforum.php?f=102"
             }
         ]
     },


### PR DESCRIPTION
Fixes https://community.brave.com/t/yandex-ads-on-drive/498967

When investigating why uBO was able to block this, and we didn't. Noticed they were using another uBO specific list from the same author, which we should use also. 