### PR TITLE
Use another mirror for URLhaus malware domain

### DIFF
--- a/filter_lists/default.json
+++ b/filter_lists/default.json
@@ -78,7 +78,7 @@
                 "support_url": "https://easylist.to/"
             },
             {
-                "url": "https://malware-filter.gitlab.io/urlhaus-filter/urlhaus-filter-agh.txt",
+                "url": "https://malware-filter.gitlab.io/urlhaus-filter/urlhaus-filter-agh-online.txt",
                 "title": "URLhaus Malicious URL Blocklist",
                 "format": "Standard",
                 "support_url": "https://gitlab.com/malware-filter/urlhaus-filter"

--- a/filter_lists/default.json
+++ b/filter_lists/default.json
@@ -78,7 +78,7 @@
                 "support_url": "https://easylist.to/"
             },
             {
-                "url": "https://malware-filter.gitlab.io/malware-filter/urlhaus-filter-agh-online.txt",
+                "url": "https://malware-filter.gitlab.io/urlhaus-filter/urlhaus-filter-agh.txt",
                 "title": "URLhaus Malicious URL Blocklist",
                 "format": "Standard",
                 "support_url": "https://gitlab.com/malware-filter/urlhaus-filter"


### PR DESCRIPTION
Current url is causing issues

`[2023-08-05T19:56:14.621Z] Spurious error: Error when fetching https://malware-filter.gitlab.io/malware-filter/urlhaus-filter-agh-online.txt: terminated`

Using another mirror from https://gitlab.com/malware-filter/urlhaus-filter