### PR TITLE
Use filters-mirror.txt

### DIFF
--- a/filter_lists/default.json
+++ b/filter_lists/default.json
@@ -12,8 +12,8 @@
         },
         "sources": [
             {
-                "url": "https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/filters.txt",
-                "title": "uBlock Origin Filters",
+                "url": "https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/filters-mirror.txt",
+                "title": "uBlock Origin Filters (brave-mirror)",
                 "format": "Standard",
                 "support_url": "https://github.com/uBlockOrigin/uAssets"
             },


### PR DESCRIPTION
From: https://github.com/brave/adblock-lists/pull/1270

This is a temp solution. Won't gaurantee no youtube ads, but easier to debug not having 6 exception rules