### PR TITLE
Switch to new urlhaus-filter source

### DIFF
--- a/filter_lists/list_catalog.json
+++ b/filter_lists/list_catalog.json
@@ -81,7 +81,7 @@
                 "support_url": "https://easylist.to/"
             },
             {
-                "url": "https://malware-filter.gitlab.io/malware-filter/urlhaus-filter-agh-online.txt",
+                "url": "https://malware-filter.gitlab.io/urlhaus-filter/urlhaus-filter-ag-online.txt",
                 "title": "URLhaus Malicious URL Blocklist",
                 "format": "Standard",
                 "support_url": "https://gitlab.com/malware-filter/urlhaus-filter"


### PR DESCRIPTION
From; https://github.com/brave/uBlock/pull/173/files#diff-b4c7d6155408f70152caa5fbcc3355293a6864d902e8cb11c2531d3da5c07620R224

We should switch to using the same list, difference is every line is using `$all` instead of `^`