### PR TITLE
Include uBO Cookie notices

### DIFF
--- a/filter_lists/list_catalog.json
+++ b/filter_lists/list_catalog.json
@@ -177,6 +177,12 @@
                 "title": "uBlock filters – Cookie Notices",
                 "format": "Standard",
                 "support_url": "https://github.com/uBlockOrigin/uAssets"
+            },
+            {
+                "url": "https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/brave-cookie-specific.txt",
+                "tille": "Brave-specific cookie additions",
+                "formart": "Standard",
+                "support_url": "https://github.com/brave/adblock-lists"
             }
         ]
     },

--- a/filter_lists/list_catalog.json
+++ b/filter_lists/list_catalog.json
@@ -171,6 +171,12 @@
                 "title": "EasyList-Cookie",
                 "format": "Standard",
                 "support_url": "https://forums.lanik.us/"
+            },
+            {
+                "url": "https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/annoyances-cookies.txt",
+                "title": "uBlock filters – Cookie Notices",
+                "format": "Standard",
+                "support_url": "https://github.com/uBlockOrigin/uAssets"
             }
         ]
     },


### PR DESCRIPTION
When we land trusted support, we should land the appropiate cookie list.