### PR TITLE
Let FB Annoyances use ELC filters

### DIFF
--- a/filter_lists/list_catalog.json
+++ b/filter_lists/list_catalog.json
@@ -180,7 +180,7 @@
             },
             {
                 "url": "https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/brave-cookie-specific.txt",
-                "tille": "Brave-specific cookie additions",
+                "title": "Brave-specific cookie additions",
                 "formart": "Standard",
                 "support_url": "https://github.com/brave/adblock-lists"
             }
@@ -202,6 +202,18 @@
                 "url": "https://secure.fanboy.co.nz/fanboy-annoyance_ubo.txt",
                 "format": "Standard",
                 "support_url": "https://forums.lanik.us/"
+            },
+            {
+                "url": "https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/annoyances-cookies.txt",
+                "title": "uBlock filters – Cookie Notices",
+                "format": "Standard",
+                "support_url": "https://github.com/uBlockOrigin/uAssets"
+            },
+            {
+                "url": "https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/brave-cookie-specific.txt",
+                "title": "Brave-specific cookie additions",
+                "formart": "Standard",
+                "support_url": "https://github.com/brave/adblock-lists"
             }
         ]
     },


### PR DESCRIPTION
Fix typo "Title:"

Annoyances includes Easylist Cookie, we should also include the same lists here.