### PR TITLE
fix typo in `format` field

### DIFF
--- a/filter_lists/list_catalog.json
+++ b/filter_lists/list_catalog.json
@@ -181,7 +181,7 @@
             {
                 "url": "https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/brave-cookie-specific.txt",
                 "tille": "Brave-specific cookie additions",
-                "formart": "Standard",
+                "format": "Standard",
                 "support_url": "https://github.com/brave/adblock-lists"
             }
         ]


### PR DESCRIPTION
see https://github.com/brave/adblock-resources/commit/3662582f1eaeb411b750d95a40ac01ae89d930f0#diff-2c247912892a1cdce3a5872b14530a7573a675dcdf007e86f06f95c14e86b9c8R184