### PR TITLE
Fixes gpc detection in brave-fix.

### DIFF
--- a/resources/brave-fix.js
+++ b/resources/brave-fix.js
@@ -2,3 +2,5 @@
 /// alias bf.js
 delete Navigator.prototype.brave
 delete window.navigator.brave
+delete navigator.globalPrivacyControl
+delete Navigator.prototype.globalPrivacyControl


### PR DESCRIPTION
Fixes `https://www.sephora.com/` part of the https://github.com/brave/adblock-lists/commit/49183851984798b06f0b00214b6f86c982dc2f4e 

This will allow sephora homepage to render correctly. sephora.com on Firefox/GPC remains broken.

**Before:** 
![sephoria](https://github.com/brave/adblock-resources/assets/1659004/25ab21dd-708f-46e5-a42b-aa25476c9d32)
**After:**
![sophroafter](https://github.com/brave/adblock-resources/assets/1659004/2ad9188f-3f4e-4278-9b87-c716936c3b3d)
