### PR TITLE
Update Adguard links

### DIFF
--- a/filter_lists/list_catalog.json
+++ b/filter_lists/list_catalog.json
@@ -777,7 +777,7 @@
             {
                 "url": "https://filters.adtidy.org/ios/filters/7.txt",
                 "format": "Standard",
-                "support_url": "https://github.com/AdguardTeam/AdguardFilters"
+                "support_url": "https://github.com/AdguardTeam/AdguardFilters#adguard-filters"
             }
         ]
     },

--- a/filter_lists/list_catalog.json
+++ b/filter_lists/list_catalog.json
@@ -994,9 +994,9 @@
         },
         "sources": [
             {
-                "url": "https://adguard.com/en/filter-rules.html?id=1",
+                "url": "https://filters.adtidy.org/extension/ublock/filters/1.txt",
                 "format": "Standard",
-                "support_url": "https://forum.adguard.com/forumdisplay.php?69-%D0%A4%D0%B8%D0%BB%D1%8C%D1%82%D1%80%D1%8B-Adguard"
+                "support_url": "https://github.com/AdguardTeam/AdguardFilters#adguard-filters"
             }
         ]
     },
@@ -1129,7 +1129,7 @@
             {
                 "url": "https://filters.adtidy.org/extension/ublock/filters/13.txt",
                 "format": "Standard",
-                "support_url": "https://forum.adguard.com/forumdisplay.php?51-Filter-Rules"
+                "support_url": "https://github.com/AdguardTeam/AdguardFilters#adguard-filters"
             }
         ]
     },


### PR DESCRIPTION
Update Adguard Russian url and contact urls since `forum.adguard.com` is no longer available.