### PR TITLE
Add experimental list

### DIFF
--- a/filter_lists/list_catalog.json
+++ b/filter_lists/list_catalog.json
@@ -1154,7 +1154,7 @@
     },
     {
         "uuid": "564C3B75-8731-404C-AD7C-5683258BA0B0",
-        "title": "Experimental adblock rules",
+        "title": "Brave Experimental Adblock Rules",
         "desc": "CAUTION: Risky or experimental filter rules that may break websites",
         "langs": [],
         "component_id": "mphkinndmkhjeijpncflnnbnphjmggoi",

--- a/filter_lists/list_catalog.json
+++ b/filter_lists/list_catalog.json
@@ -1157,6 +1157,8 @@
         "title": "Experimental adblock rules",
         "desc": "CAUTION: Risky or experimental filter rules that may break websites",
         "langs": [],
+        "component_id": "mphkinndmkhjeijpncflnnbnphjmggoi",
+        "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA7r9jN9PUQtqw3bjzn15zkSYM5FMxfuU0bc0LrewdPIW1bzVpI8pR45iwpfvRvT88ZewF06x1NSyvuIuWt/Y/bjlyfZOvN7Mm5mi4wdMiILBALSo25Co5stZUY6kZN1LnmHofcdyd2zwGsFMg9S13CWkBNihRZcGQptfIGXQRmOyaZhkTUUyeg4ZE3aiD7rXEVhArCO4WgL3414l33cHmFtqGQLu+LauhvXQHS6NtfOWE9zPs8eBnT/jqx/P/oM5451jx5o6i7zCyBp0zxhBheSKRTDQwAVYKpFbKBmnAGt1IhbFaCdQT1rTURfOjoGY+OrUpY4Lvy9KDE0TynwXAAQIDAQAB",
         "list_text_component": {
             "component_id": "jcfckfokjmopfomnoebdkdhbhcgjfnbi",
             "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA7PoRxGM/LMWIvZGE8UxNv56MHvtMyR8Sg/Gj3ZSX/XUemGHd9RmYDX/uQqGA6KIwU+26aH4GZ/sMj3JETIdZvscCDMsAhILoPAMIDxWtqpsLCOXALo+UKDtrRLpogtG9WvQmdxApyT+BqnEhXIQ2PDs+eEHsmJD9xO3FR2++haWXAV0QVgAe0V6AqT26ukDaNEKfEWfWJl8gcoutVkqdvdl5RU1vEgbXNcXnYpsJ4aNlO7RG07J4JUHw9LZ7CasQMWpFEFifBjeKQpMDg7bKXOD83D5TZ+Csw9V67FGeQeLg3uFDUdp+rXMOeSxH/4l8PtemQj9O5mUPUlL+UGH/iwIDAQAB"

--- a/filter_lists/list_catalog.json
+++ b/filter_lists/list_catalog.json
@@ -1151,5 +1151,22 @@
                 "support_url": "https://abpvn.com/"
             }
         ]
+    },
+    {
+        "uuid": "564C3B75-8731-404C-AD7C-5683258BA0B0",
+        "title": "Experimental adblock rules",
+        "desc": "CAUTION: Risky or experimental filter rules that may break websites",
+        "langs": [],
+        "list_text_component": {
+            "component_id": "jcfckfokjmopfomnoebdkdhbhcgjfnbi",
+            "base64_public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA7PoRxGM/LMWIvZGE8UxNv56MHvtMyR8Sg/Gj3ZSX/XUemGHd9RmYDX/uQqGA6KIwU+26aH4GZ/sMj3JETIdZvscCDMsAhILoPAMIDxWtqpsLCOXALo+UKDtrRLpogtG9WvQmdxApyT+BqnEhXIQ2PDs+eEHsmJD9xO3FR2++haWXAV0QVgAe0V6AqT26ukDaNEKfEWfWJl8gcoutVkqdvdl5RU1vEgbXNcXnYpsJ4aNlO7RG07J4JUHw9LZ7CasQMWpFEFifBjeKQpMDg7bKXOD83D5TZ+Csw9V67FGeQeLg3uFDUdp+rXMOeSxH/4l8PtemQj9O5mUPUlL+UGH/iwIDAQAB"
+        },
+        "sources": [
+            {
+                "url": "https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/experimental.txt",
+                "format": "Standard",
+                "support_url": "https://github.com/brave/adblock-lists"
+            }
+        ]
     }
 ]


### PR DESCRIPTION
Related to: https://github.com/brave/brave-browser/issues/36244

~I don't have a top-level base64_public_key or component_id in this addition since it doesn't look like we need them any more.~ We realized that the only way to get this on iOS is to have the top-level fields. I ran `./generate_component.sh` a second time to get those values.

1. This list should NOT be enabled by default.
2. This list should be toggleable in the filter lists in brave://settings/shields/filters