### PR TITLE
Include Romanian uBO list

### DIFF
--- a/filter_lists/list_catalog.json
+++ b/filter_lists/list_catalog.json
@@ -954,7 +954,12 @@
                 "url": "https://raw.githubusercontent.com/tcptomato/ROad-Block/master/road-block-filters-light.txt",
                 "format": "Standard",
                 "support_url": "https://github.com/tcptomato/ROad-Block"
-            }
+            },
+	    {
+                "url": "https://raw.githubusercontent.com/tcptomato/ROad-Block/master/road-ubo.txt",
+		"format": "Standard",
+		"support_url": "https://github.com/tcptomato/ROad-Block"
+	    }
         ]
     },
     {


### PR DESCRIPTION
Should resolve the issue on https://github.com/brave/adblock-lists/issues/1177

Includes ubO rules for Romanian list.