### PR TITLE
Add ubo-link-shorteners.txt as default list

### DIFF
--- a/filter_lists/list_catalog.json
+++ b/filter_lists/list_catalog.json
@@ -81,6 +81,12 @@
 		"support_url": "https://github.com/uBlockOrigin/uAssets"
             },
             {
+                "url": "https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/ubo-link-shorteners.txt",
+		"title": "uBlock Origin filters - link shortners",
+                "format": "Standard",
+                "support_url": "https://github.com/uBlockOrigin/uAssets"
+            },
+            {
                 "url": "https://easylist.to/easylist/easylist.txt",
                 "title": "EasyList",
                 "format": "Standard",


### PR DESCRIPTION
Included in filters.txt by default, we should add it.

https://github.com/uBlockOrigin/uAssets/blob/master/filters/filters.txt#L14965