### PR TITLE
Add manifest template for preinstalled CRX usage

### DIFF
--- a/filter_lists/manifest.json
+++ b/filter_lists/manifest.json
@@ -1,0 +1,7 @@
+{
+  "description": "Brave Ad Block Updater extension",
+  "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsAnb1lw5UA1Ww4JIVE8PjKNlPogAdFoie+Aczk6ppQ4OrHANxz6oAk1xFuT2W3uhGOc3b/1ydIUMqOIdRFvMdEDUvKVeFyNAVXNSouFF7EBLEzcZfFtqoxeIbwEplVISUm+WUbsdVB9MInY3a4O3kNNuUijY7bmHzAqWMTrBfenw0Lqv38OfREXCiNq/+Jm/gt7FhyBd2oviXWEGp6asUwNavFnj8gQDGVvCf+dse8HRMJn00QH0MOypsZSWFZRmF08ybOu/jTiUo/TuIaHL1H8y9SR970LqsUMozu3ioSHtFh/IVgq7Nqy4TljaKsTE+3AdtjiOyHpW9ZaOkA7j2QIDAQAB",
+  "manifest_version": 2,
+  "name": "Brave Ad Block Updater (Regional Catalog)",
+  "version": "1.0.0"
+}


### PR DESCRIPTION
Turns out we need a manifest file for the preinstalled component in https://github.com/brave/brave-core/pull/22188. We currently generate the manifest file in `brave-core-crx-packager`, so this is technically duplicated, but it'll be better to have this here for now than to add yet another repo dependency in `brave-core`.

The version will be pinned at `1.0.0`, which is okay for an initial implementation. We can revisit using a "correct" version that matches what's served by the CRX packager in the future.