### PR TITLE
AddScriptlet build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ To generate `metadata.json` automatically from files in `resources/`, run `npm r
 
 Use `npm run test` after modifying the resources or metadata file to ensure the format can be accepted by `adblock-rust`.
 
-
 ## Metadata format
 
 `metadata.json` is a list of elements of the following format:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,22 @@ Custom resources should be added to the `resources` directory, and a correspondi
 
 ## Using
 
+Make sure to run `npm install`.
+
+### Adding a new scriptlet
+
+If you just want to add a new scriptlet, simply add it under `resources/`, and then run:
+
+```
+npm run addScriptlet
+```
+
+Git add your new scriptlet, and also commit the changes generated in `dist/resources.json` (this is the file that actually contains the resource and gets loaded into the browser) and `metadata.json` (which describes the resources). The `resourcePath` for your resource is what you will use to insert the scriptlet via an adblock rule.
+
+See https://github.com/brave/adblock-resources/pull/131 and https://github.com/brave/adblock-lists/pull/1310 for an example of adding a resource and using it via an adblock rule.
+
+### Advanced use
+
 This package can be imported as a library, exposing the function `readResources` which will produce the correctly formatted list of resources for use with [adblock-rust](https://github.com/brave/adblock-rust).
 
 Alternatively, `npm run build` will write all resources to `dist/resources.json` for future use.
@@ -13,6 +29,7 @@ Alternatively, `npm run build` will write all resources to `dist/resources.json`
 To generate `metadata.json` automatically from files in `resources/`, run `npm run generateMetadata`.
 
 Use `npm run test` after modifying the resources or metadata file to ensure the format can be accepted by `adblock-rust`.
+
 
 ## Metadata format
 

--- a/generateMetadataJsonFromScriptResources.js
+++ b/generateMetadataJsonFromScriptResources.js
@@ -1,7 +1,5 @@
 /**
  * Helper script that takes resources in /resources and generates the metadata.json
- * Note that this does not add the alias - please edit those manually. 
- * For instance - brave-fix script needs the "bf" alias
  */
 
 const fs = require("fs");
@@ -24,4 +22,4 @@ const metadataList = resources.map((file) => {
 console.debug(`Writing ${metadataJsonFile}... `);
 // Pretty print out
 fs.writeFileSync(metadataJsonFile, JSON.stringify(metadataList, null, 4));
-console.debug(`Done! IMPORTANT: Please edit ${metadataJsonFile} to have the right aliases for the resources`);
+console.log("Done!")

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "node build",
     "test": "node verify",
-    "generateMetadata": "node generateMetadataJsonFromScriptResources.js"
+    "generateMetadata": "node generateMetadataJsonFromScriptResources.js",
+    "addScriptlet": "npm run generateMetadata && npm run build && npm run test"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adds the `npm run addScriptlet` command that will:

```bash
npm run generateMetadata
npm run build
npm run test
```

which is all you need to do for new scriptlets.