### PR TITLE
Cover navigator.prototype.brave

### DIFF
--- a/resources/brave-fix.js
+++ b/resources/brave-fix.js
@@ -1,4 +1,5 @@
 /// brave-fix.js
 /// alias bf.js
 delete Navigator.prototype.brave
+delete navigator.prototype.brave
 delete window.navigator.brave


### PR DESCRIPTION
Cover a different case used `navigator.prototype.brave`.

