### PR TITLE
Use uBO filterlist of Adguard Japanese

### DIFF
--- a/filter_lists/list_catalog.json
+++ b/filter_lists/list_catalog.json
@@ -811,7 +811,7 @@
         },
         "sources": [
             {
-                "url": "https://filters.adtidy.org/ios/filters/7.txt",
+                "url": "https://filters.adtidy.org/extension/ublock/filters/7.txt",
                 "format": "Standard",
                 "support_url": "https://github.com/AdguardTeam/AdguardFilters#adguard-filters"
             }


### PR DESCRIPTION
We should be using this list, is more compatible with Adblock Rust

Resolves: https://community.brave.com/t/topic/553239/2