### PR TITLE
Update Iceland list to brave-lists

### DIFF
--- a/filter_lists/list_catalog.json
+++ b/filter_lists/list_catalog.json
@@ -735,9 +735,9 @@
         },
         "sources": [
             {
-                "url": "https://adblock.gardar.net/is.abp.txt",
+                "url": "https://raw.githubusercontent.com/brave/adblock-lists/master/custom/is.txt",
                 "format": "Standard",
-                "support_url": "https://adblock.gardar.net/"
+                "support_url": "https://github.com/brave/adblock-lists"
             }
         ]
     },


### PR DESCRIPTION
Update Iceland list point to brave-lists hosted. 

Ref: https://github.com/brave/adblock-lists/pull/1841