### PR TITLE
Remove Peter Lowe's as a default list

### DIFF
--- a/filter_lists/list_catalog.json
+++ b/filter_lists/list_catalog.json
@@ -111,12 +111,6 @@
                 "support_url": "https://gitlab.com/malware-filter/urlhaus-filter"
             },
             {
-                "url": "https://pgl.yoyo.org/adservers/serverlist.php?hostformat=adblockplus&showintro=1&mimetype=plaintext",
-                "title": "Peter Lowe's Ad and tracking server list",
-                "format": "Standard",
-                "support_url": "https://pgl.yoyo.org/adservers/"
-            },
-            {
                 "url": "https://raw.githubusercontent.com/brave/adblock-lists/master/brave-unbreak.txt",
                 "title": "Brave Unbreak",
                 "format": "Standard",


### PR DESCRIPTION
Given we're shipping [easyprivacy](https://easylist.to/easylist/easyprivacy.txt), this list is effectively a dupe.

- It causes issues with fixes in easyprivacy that are not applied in this list
- Both Brave and uBO need a number of $badfilter PL rules, to counter these blocks.
- This will improve privacy webcompat, less tracking breakage. 

The list is still fine, just has an excess of tracking rules that are already in Easyprivacy plus the issue of the occasional conflict due to the limitation of a hosts-only rule set. Better not to have it included as a default.