### PR TITLE
Make brave-firstparty more modular, and more manageable 

### DIFF
--- a/filter_lists/list_catalog.json
+++ b/filter_lists/list_catalog.json
@@ -185,6 +185,12 @@
                 "title": "Brave First-Party Specific Filters",
                 "format": "Standard",
                 "support_url": "https://github.com/brave/adblock-lists"
+            },
+            {
+                "url": "https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/brave-firstparty-regional.txt",
+                "title": "Brave First-Party Regional Filters",
+                "format": "Standard",
+                "support_url": "https://github.com/brave/adblock-lists"
             }
         ]
     },


### PR DESCRIPTION
Created "https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/brave-firstparty-regional.txt" 

Makes regionals more manageable, split apart from the current rules