### PR TITLE
Add brave-firstparty-antiadblock.txt

### DIFF
--- a/filter_lists/list_catalog.json
+++ b/filter_lists/list_catalog.json
@@ -197,6 +197,12 @@
                 "title": "Brave First-Party Regional Filters",
                 "format": "Standard",
                 "support_url": "https://github.com/brave/adblock-lists"
+            },
+            {
+                "url": "https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/brave-firstparty-antiadblock.txt",
+                "title": "Brave First-Party Anti-adblock Filters",
+                "format": "Standard",
+                "support_url": "https://github.com/brave/adblock-lists"
             }
         ]
     },


### PR DESCRIPTION
In sync with; https://github.com/brave/adblock-lists/pull/2417

Keep Anti-adblock filter rules into their own section. 