### PR TITLE
Add Crypto Firewall filter lists to the `list_catalog.json` file

### DIFF
--- a/filter_lists/list_catalog.json
+++ b/filter_lists/list_catalog.json
@@ -1169,7 +1169,7 @@
             {
                 "url": "https://raw.githubusercontent.com/chartingshow/crypto-firewall/master/src/blacklists/lite-version.txt",
                 "format": "Standard",
-                "support_url": "https://github.com/brave/adblock-lists"
+                "support_url": "https://github.com/chartingshow/crypto-firewall"
             }
         ]
     },
@@ -1186,7 +1186,7 @@
             {
                 "url": "https://raw.githubusercontent.com/chartingshow/crypto-firewall/master/src/blacklists/full-version.txt",
                 "format": "Standard",
-                "support_url": "https://github.com/brave/adblock-lists"
+                "support_url": "https://github.com/chartingshow/crypto-firewall"
             }
         ]
     },
@@ -1203,7 +1203,7 @@
             {
                 "url": "https://raw.githubusercontent.com/chartingshow/crypto-firewall/master/src/blacklists/mega-version.txt",
                 "format": "Standard",
-                "support_url": "https://github.com/brave/adblock-lists"
+                "support_url": "https://github.com/chartingshow/crypto-firewall"
             }
         ]
     },
@@ -1220,7 +1220,7 @@
             {
                 "url": "https://raw.githubusercontent.com/chartingshow/crypto-firewall/master/src/blacklists/beta-version.txt",
                 "format": "Standard",
-                "support_url": "https://github.com/brave/adblock-lists"
+                "support_url": "https://github.com/chartingshow/crypto-firewall"
             }
         ]
     }


### PR DESCRIPTION
## What This Pull Request Does

This pull request introduces **four distinct versions** of the Crypto Firewall filter list. Each version is carefully balanced to offer different trade-offs between performance and security, allowing users to select the option that best matches their device’s capabilities and their personal security preferences. For detailed guidance on choosing the right version, please see the [Recommended Versions section](https://github.com/chartingshow/crypto-firewall#recommended-versions-) in our documentation.

## Why These Filter Lists Are Needed

While Brave Browser’s built-in filter lists block advertisements, they do **not specifically target crypto and banking malware or scams**. The Crypto Firewall is designed to actively combat hackers and scammers by blocking known threats in these high-risk categories. To ensure ongoing protection, our definition files are **automatically updated every week** using bots that scan the internet for active crypto scams and phishing sites.

## Issue

Issue: https://github.com/brave/adblock-resources/issues/256

## Notes

The `generate-keys.sh` doesn't work on a Windows computer running Git Bash.

The following error message `uuidgen: command not found` was being generated, to fix the error we corrected the code line:

```bash
echo "uuid: $(uuidgen)"
```

into 

```bash
echo "uuid: $(powershell -command "[guid]::NewGuid().ToString()")"
```
