### PR TITLE
Include AI suggestions list

### DIFF
--- a/filter_lists/list_catalog.json
+++ b/filter_lists/list_catalog.json
@@ -450,6 +450,11 @@
                 "url": "https://raw.githubusercontent.com/laylavish/uBlockOrigin-HUGE-AI-Blocklist/refs/heads/main/additional_list_nuclear.txt",
                 "format": "Standard",
                 "support_url": "https://github.com/laylavish/uBlockOrigin-HUGE-AI-Blocklist"
+            },
+            {
+                "url": "https://raw.githubusercontent.com/easylist/easylist/refs/heads/master/fanboy-addon/fanboy_ai_suggestions.txt",
+                "format": "Standard",
+                "support_url": "https://forums.lanik.us/"
             }
          ]
     },


### PR DESCRIPTION
From the recent change. https://github.com/brave/adblock-resources/pull/270

We can include the removal of AI search suggestions (optional list).