### PR TITLE
Update Korean list to List-KR proper

### DIFF
--- a/filter_lists/list_catalog.json
+++ b/filter_lists/list_catalog.json
@@ -937,9 +937,9 @@
         },
         "sources": [
             {
-                "url": "https://raw.githubusercontent.com/yous/YousList/master/youslist.txt",
+                "url": "https://cdn.jsdelivr.net/npm/@list-kr/filterslists@latest/dist/filterslist-uBlockOrigin-classic.txt",
                 "format": "Standard",
-                "support_url": "https://github.com/yous/YousList"
+                "support_url": "https://github.com/List-KR/List-KR"
             }
         ]
     },


### PR DESCRIPTION
Fix https://github.com/brave/adblock-resources/issues/104.

Match uBO Support and contentURL

https://github.com/gorhill/uBlock/blob/master/assets/assets.json#L753

```
	"KOR-1": {
		"content": "filters",
		"group": "regions",
		"off": true,
		"title": "🇰🇷kr: List-KR Classic",
		"tags": "ads korean 한국어",
		"lang": "ko",
		"contentURL": "https://cdn.jsdelivr.net/npm/@list-kr/filterslists@latest/dist/filterslist-uBlockOrigin-classic.txt",
		"supportURL": "https://github.com/List-KR/List-KR#readme"
	},
```