### PR TITLE
Include EasyListHebrew-uBO.txt

### DIFF
--- a/filter_lists/list_catalog.json
+++ b/filter_lists/list_catalog.json
@@ -818,6 +818,11 @@
                 "url": "https://raw.githubusercontent.com/easylist/EasyListHebrew/master/EasyListHebrew.txt",
                 "format": "Standard",
                 "support_url": "https://github.com/easylist/EasyListHebrew"
+            },
+            {
+                "url": "https://raw.githubusercontent.com/easylist/EasyListHebrew/refs/heads/master/EasyListHebrew-uBO.txt",
+                "format": "Standard",
+                "support_url": "https://github.com/easylist/EasyListHebrew"
             }
         ]
     },


### PR DESCRIPTION
Missing supplemental uBO list.

Address https://community.brave.app/t/haaretz-co-il-and-themarker-com-detect-brave-shields-and-trigger-anti-adblock-warnings/655921